### PR TITLE
Timestamp Feature

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/models/ChatMessage.java
+++ b/backend/src/main/java/com/github/wekaito/backend/models/ChatMessage.java
@@ -1,13 +1,15 @@
 package com.github.wekaito.backend.models;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public record ChatMessage(
     String id,
     String message,
-    String author
+    String author,
+    String timestamp
 ) {
     public ChatMessage(String message, String author) {
-        this(UUID.randomUUID().toString(), message, author);
+        this(UUID.randomUUID().toString(), message, author, Instant.now().toString());
     }
 }

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -615,7 +615,10 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     private void handleChatMessage(WebSocketSession session, String payload) throws IOException {
         if (payload.substring("/chatMessage:".length()).trim().isEmpty()) return;
 
-        String username = Objects.requireNonNull(session.getPrincipal()).getName();
+        Principal principal = session.getPrincipal();
+        if (principal == null) return;
+
+        String username = principal.getName();
 
         String messageContent = payload.substring("/chatMessage:".length());
         ChatMessage chatMessage = new ChatMessage(messageContent, username);
@@ -631,15 +634,20 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     private void handleRoomChatMessage(WebSocketSession session, String payload) throws IOException {
         String[] parts = payload.split(":", 3);
-        String chatMessage = parts[1];
+        String messageContent = parts[1];
         String roomId = parts[2];
-        String userName = Objects.requireNonNull(session.getPrincipal()).getName();
+        Principal principal = session.getPrincipal();
+        if (principal == null) return;
+
+        String userName = principal.getName();
 
         Room room = getRoomById(roomId);
         if (room == null) return;
 
+        ChatMessage chatMessage = new ChatMessage(messageContent, userName);
+
         for (LobbyPlayer player : room.getPlayers()) {
-            sendTextMessage(player.getSession(), "[CHAT_MESSAGE_ROOM]:" + userName + ": " + chatMessage);
+            sendTextMessage(player.getSession(), "[CHAT_MESSAGE_ROOM]:" + objectMapper.writeValueAsString(chatMessage));
         }
     }
 

--- a/frontend/src/components/lobby/Chat.tsx
+++ b/frontend/src/components/lobby/Chat.tsx
@@ -36,6 +36,24 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
         }).format(date);
     }
 
+    function formatTimestampTitle(timestamp: string) {
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return "";
+
+        const parts = new Intl.DateTimeFormat(undefined, {
+            month: "2-digit",
+            day: "2-digit",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true,
+        }).formatToParts(date);
+
+        const value = (type: Intl.DateTimeFormatPartTypes) => parts.find((part) => part.type === type)?.value ?? "";
+
+        return `${value("month")}/${value("day")}/${value("year")} ${value("hour")}:${value("minute")} ${value("dayPeriod")}`;
+    }
+
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
         if (!message.trim().length) return;
@@ -65,10 +83,10 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
                                 data-message-id={message.id}
                                 onContextMenu={(e) => handleContextMenu(e, message)}
                             >
-                            <StyledServerSpan>
-                                <span>Server </span>
-                                <span> </span>
-                                {message.message === "Join our Discord!" ? (
+                                <StyledServerSpan>
+                                    <span>Server </span>
+                                    <span> </span>
+                                    {message.message === "Join our Discord!" ? (
                                         <>
                                             <a
                                                 href="https://discord.gg/sBdByGAh2y"
@@ -99,7 +117,9 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
                             onContextMenu={(e) => handleContextMenu(e, message)}
                         >
                             <StyledSpan isMe={user === message.author}>
-                            <StyledTimestamp dateTime={message.timestamp}>[{formatTimestamp(message.timestamp)}]</StyledTimestamp>
+                                <StyledTimestamp dateTime={message.timestamp} title={formatTimestampTitle(message.timestamp)}>
+                                    [{formatTimestamp(message.timestamp)}]
+                                </StyledTimestamp>
                                 <span>{message.author + " "}</span>
                                 <span> </span>
                                 <span className={"text"}>{message.message}</span>

--- a/frontend/src/components/lobby/Chat.tsx
+++ b/frontend/src/components/lobby/Chat.tsx
@@ -9,6 +9,7 @@ export type ChatMessage = {
     id: string;
     message: string;
     author: string;
+    timestamp: string;
 };
 
 type Props = {
@@ -24,6 +25,16 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
     const { show: showChatMessageMenu } = useContextMenu({ id: "chat-message-menu" });
 
     const historyRef = useRef<HTMLDivElement>(null);
+
+    function formatTimestamp(timestamp: string) {
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return "";
+
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+        }).format(date);
+    }
 
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -54,10 +65,10 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
                                 data-message-id={message.id}
                                 onContextMenu={(e) => handleContextMenu(e, message)}
                             >
-                                <StyledServerSpan>
-                                    <span>Server </span>
-                                    <span> </span>
-                                    {message.message === "Join our Discord!" ? (
+                            <StyledServerSpan>
+                                <span>Server </span>
+                                <span> </span>
+                                {message.message === "Join our Discord!" ? (
                                         <>
                                             <a
                                                 href="https://discord.gg/sBdByGAh2y"
@@ -88,6 +99,7 @@ export default function Chat({ sendMessage, messages, roomId }: Props) {
                             onContextMenu={(e) => handleContextMenu(e, message)}
                         >
                             <StyledSpan isMe={user === message.author}>
+                            <StyledTimestamp dateTime={message.timestamp}>[{formatTimestamp(message.timestamp)}]</StyledTimestamp>
                                 <span>{message.author + " "}</span>
                                 <span> </span>
                                 <span className={"text"}>{message.message}</span>
@@ -170,6 +182,14 @@ const StyledServerSpan = styled.span`
         color: #31da75;
         border-bottom-right-radius: 4px;
     }
+`;
+
+const StyledTimestamp = styled.time`
+    color: rgba(255, 239, 213, 0.62);
+    font-family: "Cousine", monospace;
+    font-size: 0.6em;
+    margin-right: 6px;
+    white-space: nowrap;
 `;
 
 const StyledInput = styled.input`

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -37,6 +37,30 @@ import useQuery from "../hooks/useQuery.ts";
 import PatchnotesLink from "../components/PatchnotesLink.tsx";
 import ChatContextMenu from "../components/lobby/ChatContextMenu.tsx";
 
+function ensureChatTimestamp(chatMessage: ChatMessage): ChatMessage {
+    return {
+        ...chatMessage,
+        timestamp: chatMessage.timestamp ?? new Date().toISOString(),
+    };
+}
+
+function parseChatMessage(messageJson: string): ChatMessage {
+    try {
+        return ensureChatTimestamp(JSON.parse(messageJson) as ChatMessage);
+    } catch {
+        const separatorIndex = messageJson.indexOf(":");
+        const author = separatorIndex >= 0 ? messageJson.substring(0, separatorIndex) : "【SERVER】";
+        const message = separatorIndex >= 0 ? messageJson.substring(separatorIndex + 1).trimStart() : messageJson;
+
+        return {
+            id: `${Date.now()}-${Math.random()}`,
+            author,
+            message,
+            timestamp: new Date().toISOString(),
+        };
+    }
+}
+
 type LobbyPlayer = {
     name: string;
     avatarName: string;
@@ -220,18 +244,18 @@ export default function Lobby() {
 
                 if (event.data.startsWith("[GLOBAL_CHAT]:")) {
                     const messagesArray = JSON.parse(event.data.substring("[GLOBAL_CHAT]:".length)) as ChatMessage[];
-                    setMessages(messagesArray);
+                    setMessages(messagesArray.map(ensureChatTimestamp));
                 }
 
                 if (event.data.startsWith("[CHAT_MESSAGE]:") && !joinedRoom) {
                     const messageJson = event.data.substring("[CHAT_MESSAGE]:".length);
-                    const chatMessage = JSON.parse(messageJson) as ChatMessage;
+                    const chatMessage = parseChatMessage(messageJson);
                     setMessages((messages) => [...messages, chatMessage]);
                 }
 
                 if (event.data.startsWith("[CHAT_MESSAGE_ROOM]:")) {
                     const messageJson = event.data.substring("[CHAT_MESSAGE_ROOM]:".length);
-                    const chatMessage = JSON.parse(messageJson) as ChatMessage;
+                    const chatMessage = parseChatMessage(messageJson);
                     setPrivateMessages((messages) => [...messages, chatMessage]);
                 }
 


### PR DESCRIPTION
 Implemented the lobby chat timestamp feature.

  What changed:

  - Added timestamp to backend ChatMessage records as an ISO instant.
  - Hovering over timestamp shows full date
  - Global lobby chat and private room chat now send JSON messages with timestamps.
  - Chat.tsx renders the timestamp next to the author using the viewer’s local timezone via Intl.DateTimeFormat.
  - Lobby.tsx now backfills a timestamp for older/legacy messages that do not include one.
  - Added a defensive guard so unauthenticated websocket chat payloads do not throw a backend NPE.

  Verification:

  - npm run build passed.
  - Backend compile with -DskipTests package passed.
  - Restarted the rebuilt backend on localhost:8080.
  - Frontend proxy check returned 200 OK.

  Note: your working tree also includes earlier local changes in ChatContextMenu.tsx, local dev URL files, and the useLayoutEffect warning fixes.

<img width="1495" height="645" alt="Screenshot 2026-07-14 at 11 09 42 PM" src="https://github.com/user-attachments/assets/5e23dfe9-4d17-460d-8931-bd2fb06c2396" />

<img width="631" height="251" alt="Screenshot 2026-07-14 at 11 17 36 PM" src="https://github.com/user-attachments/assets/7a9c1762-0f79-466c-a808-dae20eb580ca" />

