### PR TITLE
Added DP modifier shortcut

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -261,15 +261,16 @@ export default function Card(props: CardProps) {
     useEffect(() => {
         if (!isSelected) return;
 
-        const addDpModifier = (event: KeyboardEvent) => {
+        const changeDpModifier = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const isTyping =
                 target instanceof HTMLInputElement ||
                 target instanceof HTMLTextAreaElement ||
                 target instanceof HTMLSelectElement ||
                 target?.isContentEditable;
+            const key = event.key.toLowerCase();
 
-            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (!["p", "m"].includes(key) || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
             if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
 
             const currentCard = (
@@ -279,7 +280,7 @@ export default function Card(props: CardProps) {
 
             const modifiers = {
                 ...currentCard.modifiers,
-                plusDp: currentCard.modifiers.plusDp + 1000,
+                plusDp: currentCard.modifiers.plusDp + (key === "p" ? 1000 : -1000),
             };
 
             setModifiers(card.id, location, modifiers);
@@ -290,8 +291,8 @@ export default function Card(props: CardProps) {
             wsUtils?.sendSfx("playModifyCardSfx");
         };
 
-        document.addEventListener("keydown", addDpModifier);
-        return () => document.removeEventListener("keydown", addDpModifier);
+        document.addEventListener("keydown", changeDpModifier);
+        return () => document.removeEventListener("keydown", changeDpModifier);
     }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -214,6 +214,7 @@ export default function Card(props: CardProps) {
     const setLinkCardInfo = useGameBoardStates((state) => state.setLinkCardInfo);
     const getLinkCardsForLocation = useGameBoardStates((state) => state.getLinkCardsForLocation);
     const setCardToSend = useGameBoardStates((state) => state.setCardToSend);
+    const setModifiers = useGameBoardStates((state) => state.setModifiers);
     const getCardLocationById = useGameBoardStates((state) => state.getCardLocationById);
     const isHandHidden = useGameBoardStates((state) => state.isHandHidden);
     const stackSliceIndex = useGameBoardStates((state) => state.stackSliceIndex);
@@ -232,6 +233,7 @@ export default function Card(props: CardProps) {
 
     const playSuspendSfx = useSound((state) => state.playSuspendSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
+    const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
 
     const cachedImageUrl = useImageCache(card.imgUrl);
     const [cardImageUrl, setCardImageUrl] = useState(cachedImageUrl || card.imgUrl);
@@ -255,6 +257,42 @@ export default function Card(props: CardProps) {
 
         return () => document.removeEventListener("click", clearSelection);
     }, [isSelected, selectCard]);
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const addDpModifier = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            const isTyping =
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target instanceof HTMLSelectElement ||
+                target?.isContentEditable;
+
+            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
+
+            const currentCard = (
+                useGameBoardStates.getState()[location as keyof ReturnType<typeof useGameBoardStates.getState>] as CardTypeGame[]
+            ).find((locationCard) => locationCard.id === card.id);
+            if (!currentCard) return;
+
+            const modifiers = {
+                ...currentCard.modifiers,
+                plusDp: currentCard.modifiers.plusDp + 1000,
+            };
+
+            setModifiers(card.id, location, modifiers);
+            playModifyCardSfx();
+            wsUtils?.sendMessage(
+                `${wsUtils.matchInfo.gameId}:/setModifiers:${wsUtils.matchInfo.opponentName}:${card.id}:${location}:${JSON.stringify(modifiers)}`
+            );
+            wsUtils?.sendSfx("playModifyCardSfx");
+        };
+
+        document.addEventListener("keydown", addDpModifier);
+        return () => document.removeEventListener("keydown", addDpModifier);
+    }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -245,6 +245,16 @@ export default function Card(props: CardProps) {
 
     const [renderEffectAnimation, setRenderEffectAnimation] = useState(false);
     const [renderTargetAnimation, setRenderTargetAnimation] = useState(false);
+    const isSelected = selectedCard?.id === card.id;
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const clearSelection = () => selectCard(null);
+        document.addEventListener("click", clearSelection);
+
+        return () => document.removeEventListener("click", clearSelection);
+    }, [isSelected, selectCard]);
 
     const inTamerField = tamerLocations.includes(location);
 
@@ -568,6 +578,10 @@ export default function Card(props: CardProps) {
                             filter: "brightness(0.5) saturate(1.25) hue-rotate(30deg)",
                         }),
                         ...(markedCard === card.id && { outline: "3px solid red" }),
+                        ...(isSelected && {
+                            outline: "3px solid limegreen",
+                            outlineOffset: "-2px",
+                        }),
                     }}
                     className={opponentFieldLocations?.includes(location) ? undefined : "custom-hand-cursor"}
                     onClick={handleClick}


### PR DESCRIPTION
 ## Summary

  Adds keyboard-driven DP modifier controls for selected cards.

  - Clicking a card selects it and displays a green frame.
  - Clicking away clears the selection and removes the frame.
  - Pressing p adds 1000 DP to the selected card.
  - Pressing m subtracts 1000 DP from the selected card.
  - Repeated keypresses continue adjusting DP.
  - DP changes preserve existing card modifiers.
  - Modifier changes play the existing sound effect and synchronize with the opponent over WebSocket.
  - Keyboard shortcuts are disabled while typing in form fields.
  - Shortcuts only apply to cards that support DP modifiers.

  ## Testing

  - Confirmed the frontend production build completes successfully.
  - Verified existing drag-stack and marked-card outlines remain supported.

By clicking on a card, it should now show a green frame showing that the card is in a selected state. The player can press "p" to increase/ "m" to decrease the DP easily so they don't have to keep clicking on the modifier menu.

<img width="705" height="336" alt="Screenshot 2026-07-15 at 1 06 54 PM" src="https://github.com/user-attachments/assets/630a5368-b4ca-43d8-a410-9d219c755bd9" />
