### PR TITLE
Created Shortcut Keys for Field Removal

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -205,6 +205,7 @@ export default function Card(props: CardProps) {
 
     const tiltCard = useGameBoardStates((state) => state.tiltCard);
     const moveCard = useGameBoardStates((state) => state.moveCard);
+    const moveCardToStack = useGameBoardStates((state) => state.moveCardToStack);
     const locationCards = useGameBoardStates((state) => state[location as keyof typeof state] as CardTypeGame[]);
     const hoverCard = useGeneralStates((state) => state.hoverCard);
     const cardIdWithEffect = useGameBoardStates((state) => state.cardIdWithEffect);
@@ -236,6 +237,7 @@ export default function Card(props: CardProps) {
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
     const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
     const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
+    const playPlaceCardSfx = useSound((state) => state.playPlaceCardSfx);
 
     const cachedImageUrl = useImageCache(card.imgUrl);
     const [cardImageUrl, setCardImageUrl] = useState(cachedImageUrl || card.imgUrl);
@@ -276,6 +278,49 @@ export default function Card(props: CardProps) {
                 target?.isContentEditable;
             const key = event.key.toLowerCase();
             const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
+
+            if (
+                key === "b" &&
+                !isTyping &&
+                !hasModifierKey &&
+                [...myDigimonLocations, "myBreedingArea"].includes(location)
+            ) {
+                event.preventDefault();
+                const stack = [
+                    ...(useGameBoardStates.getState()[
+                        location as keyof ReturnType<typeof useGameBoardStates.getState>
+                    ] as CardTypeGame[]),
+                ];
+                const topCard = stack.at(-1);
+                if (!topCard || topCard.cardType === "Token" || topCard.id.startsWith("TOKEN")) return;
+                const remainingStack = stack.slice(0, -1);
+
+                moveCardToStack("Bottom", topCard.id, location, "myDeckField");
+                remainingStack.forEach((stackCard) => {
+                    moveCard(stackCard.id, location, "myTrash");
+                    wsUtils?.sendMoveCard(stackCard.id, location, "myTrash");
+                });
+                selectCard(null);
+                playPlaceCardSfx();
+                wsUtils?.sendMessage(
+                    `${wsUtils.matchInfo.gameId}:/moveCardToStack:Bottom:${topCard.id}:${location}:myDeckField:undefined`
+                );
+                wsUtils?.sendSfx("playPlaceCardSfx");
+                wsUtils?.sendChatMessage(
+                    `[FIELD_UPDATE]≔【${topCard.name}】﹕${convertForLog(location)} ➟ Deck Bottom`
+                );
+                if (remainingStack.length) {
+                    playTrashCardSfx();
+                    wsUtils?.sendSfx("playTrashCardSfx");
+                    const remainingCardNames = remainingStack
+                        .map((stackCard) => `【${stackCard.isFaceUp ? stackCard.name : "❔"}】`)
+                        .join("");
+                    wsUtils?.sendChatMessage(
+                        `[FIELD_UPDATE]≔${remainingCardNames}﹕${convertForLog(location)} ➟ ${convertForLog("myTrash")}`
+                    );
+                }
+                return;
+            }
 
             if (key === "d" && !isTyping && !hasModifierKey && myBALocations.includes(location)) {
                 event.preventDefault();
@@ -333,7 +378,9 @@ export default function Card(props: CardProps) {
         isDirectlySelected,
         location,
         moveCard,
+        moveCardToStack,
         playModifyCardSfx,
+        playPlaceCardSfx,
         playTrashCardSfx,
         selectCard,
         setModifiers,

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -261,15 +261,16 @@ export default function Card(props: CardProps) {
     useEffect(() => {
         if (!isSelected) return;
 
-        const addDpModifier = (event: KeyboardEvent) => {
+        const changeDpModifier = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const isTyping =
                 target instanceof HTMLInputElement ||
                 target instanceof HTMLTextAreaElement ||
                 target instanceof HTMLSelectElement ||
                 target?.isContentEditable;
+            const key = event.key.toLowerCase();
 
-            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (!["p", "m"].includes(key) || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
             if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
 
             const currentCard = (
@@ -279,7 +280,7 @@ export default function Card(props: CardProps) {
 
             const modifiers = {
                 ...currentCard.modifiers,
-                plusDp: currentCard.modifiers.plusDp + 1000,
+                plusDp: currentCard.modifiers.plusDp + (key === "p" ? 1000 : -1000),
             };
 
             setModifiers(card.id, location, modifiers);
@@ -290,8 +291,8 @@ export default function Card(props: CardProps) {
             wsUtils?.sendSfx("playModifyCardSfx");
         };
 
-        document.addEventListener("keydown", addDpModifier);
-        return () => document.removeEventListener("keydown", addDpModifier);
+        document.addEventListener("keydown", changeDpModifier);
+        return () => document.removeEventListener("keydown", changeDpModifier);
     }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -214,6 +214,7 @@ export default function Card(props: CardProps) {
     const setLinkCardInfo = useGameBoardStates((state) => state.setLinkCardInfo);
     const getLinkCardsForLocation = useGameBoardStates((state) => state.getLinkCardsForLocation);
     const setCardToSend = useGameBoardStates((state) => state.setCardToSend);
+    const setModifiers = useGameBoardStates((state) => state.setModifiers);
     const getCardLocationById = useGameBoardStates((state) => state.getCardLocationById);
     const isHandHidden = useGameBoardStates((state) => state.isHandHidden);
     const stackSliceIndex = useGameBoardStates((state) => state.stackSliceIndex);
@@ -232,6 +233,7 @@ export default function Card(props: CardProps) {
 
     const playSuspendSfx = useSound((state) => state.playSuspendSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
+    const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
 
     const cachedImageUrl = useImageCache(card.imgUrl);
     const [cardImageUrl, setCardImageUrl] = useState(cachedImageUrl || card.imgUrl);
@@ -255,6 +257,42 @@ export default function Card(props: CardProps) {
 
         return () => document.removeEventListener("click", clearSelection);
     }, [isSelected, selectCard]);
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const addDpModifier = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            const isTyping =
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target instanceof HTMLSelectElement ||
+                target?.isContentEditable;
+
+            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
+
+            const currentCard = (
+                useGameBoardStates.getState()[location as keyof ReturnType<typeof useGameBoardStates.getState>] as CardTypeGame[]
+            ).find((locationCard) => locationCard.id === card.id);
+            if (!currentCard) return;
+
+            const modifiers = {
+                ...currentCard.modifiers,
+                plusDp: currentCard.modifiers.plusDp + 1000,
+            };
+
+            setModifiers(card.id, location, modifiers);
+            playModifyCardSfx();
+            wsUtils?.sendMessage(
+                `${wsUtils.matchInfo.gameId}:/setModifiers:${wsUtils.matchInfo.opponentName}:${card.id}:${location}:${JSON.stringify(modifiers)}`
+            );
+            wsUtils?.sendSfx("playModifyCardSfx");
+        };
+
+        document.addEventListener("keydown", addDpModifier);
+        return () => document.removeEventListener("keydown", addDpModifier);
+    }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -280,6 +280,47 @@ export default function Card(props: CardProps) {
             const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
 
             if (
+                key === "s" &&
+                !isTyping &&
+                !hasModifierKey &&
+                [...myDigimonLocations, "myBreedingArea"].includes(location)
+            ) {
+                event.preventDefault();
+                const stack = [
+                    ...(useGameBoardStates.getState()[
+                        location as keyof ReturnType<typeof useGameBoardStates.getState>
+                    ] as CardTypeGame[]),
+                ];
+                const topCard = stack.at(-1);
+                if (!topCard || topCard.cardType === "Token" || topCard.id.startsWith("TOKEN")) return;
+                const remainingStack = stack.slice(0, -1);
+
+                moveCardToStack("Top", topCard.id, location, "mySecurity", "down");
+                remainingStack.forEach((stackCard) => {
+                    moveCard(stackCard.id, location, "myTrash");
+                    wsUtils?.sendMoveCard(stackCard.id, location, "myTrash");
+                });
+                selectCard(null);
+                wsUtils?.sendMessage(
+                    `${wsUtils.matchInfo.gameId}:/moveCardToStack:Top:${topCard.id}:${location}:mySecurity:down`
+                );
+                wsUtils?.sendChatMessage(
+                    `[FIELD_UPDATE]≔【${topCard.name}】﹕${convertForLog(location)} ➟ SS Top(face down)`
+                );
+                if (remainingStack.length) {
+                    playTrashCardSfx();
+                    wsUtils?.sendSfx("playTrashCardSfx");
+                    const remainingCardNames = remainingStack
+                        .map((stackCard) => `【${stackCard.isFaceUp ? stackCard.name : "❔"}】`)
+                        .join("");
+                    wsUtils?.sendChatMessage(
+                        `[FIELD_UPDATE]≔${remainingCardNames}﹕${convertForLog(location)} ➟ ${convertForLog("myTrash")}`
+                    );
+                }
+                return;
+            }
+
+            if (
                 key === "b" &&
                 !isTyping &&
                 !hasModifierKey &&

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { BootStage, CardTypeGame } from "../utils/types.ts";
 import styled from "@emotion/styled";
 import { useGeneralStates } from "../hooks/useGeneralStates.ts";
 import { tamerLocations, useGameBoardStates } from "../hooks/useGameBoardStates.ts";
-import { getNumericModifier, numbersWithModifiers } from "../utils/functions.ts";
+import { convertForLog, getNumericModifier, numbersWithModifiers } from "../utils/functions.ts";
 import { CSSProperties, useEffect, useState } from "react";
 import Lottie from "lottie-react";
 import activateEffectAnimation from "../assets/lotties/activate-effect-animation.json";
@@ -204,6 +204,7 @@ export default function Card(props: CardProps) {
               : player1.mainSleeveName;
 
     const tiltCard = useGameBoardStates((state) => state.tiltCard);
+    const moveCard = useGameBoardStates((state) => state.moveCard);
     const locationCards = useGameBoardStates((state) => state[location as keyof typeof state] as CardTypeGame[]);
     const hoverCard = useGeneralStates((state) => state.hoverCard);
     const cardIdWithEffect = useGameBoardStates((state) => state.cardIdWithEffect);
@@ -234,6 +235,7 @@ export default function Card(props: CardProps) {
     const playSuspendSfx = useSound((state) => state.playSuspendSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
     const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
+    const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
 
     const cachedImageUrl = useImageCache(card.imgUrl);
     const [cardImageUrl, setCardImageUrl] = useState(cachedImageUrl || card.imgUrl);
@@ -247,21 +249,25 @@ export default function Card(props: CardProps) {
 
     const [renderEffectAnimation, setRenderEffectAnimation] = useState(false);
     const [renderTargetAnimation, setRenderTargetAnimation] = useState(false);
-    const isSelected = selectedCard?.id === card.id;
+    const isDirectlySelected = selectedCard?.id === card.id;
+    const selectedCardLocation = getCardLocationById(selectedCard?.id ?? "");
+    const isFieldStack =
+        location.includes("Digi") || location.includes("Link") || location.includes("Breeding");
+    const isSelected = isDirectlySelected || (isFieldStack && selectedCardLocation === location);
 
     useEffect(() => {
-        if (!isSelected) return;
+        if (!isDirectlySelected) return;
 
         const clearSelection = () => selectCard(null);
         document.addEventListener("click", clearSelection);
 
         return () => document.removeEventListener("click", clearSelection);
-    }, [isSelected, selectCard]);
+    }, [isDirectlySelected, selectCard]);
 
     useEffect(() => {
-        if (!isSelected) return;
+        if (!isDirectlySelected) return;
 
-        const changeDpModifier = (event: KeyboardEvent) => {
+        const handleSelectedCardShortcut = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const isTyping =
                 target instanceof HTMLInputElement ||
@@ -269,8 +275,34 @@ export default function Card(props: CardProps) {
                 target instanceof HTMLSelectElement ||
                 target?.isContentEditable;
             const key = event.key.toLowerCase();
+            const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
 
-            if (!["p", "m"].includes(key) || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (key === "d" && !isTyping && !hasModifierKey && myBALocations.includes(location)) {
+                event.preventDefault();
+                const stack = [
+                    ...(useGameBoardStates.getState()[
+                        location as keyof ReturnType<typeof useGameBoardStates.getState>
+                    ] as CardTypeGame[]),
+                ];
+                if (!stack.length) return;
+
+                selectCard(null);
+                stack.forEach((stackCard) => {
+                    moveCard(stackCard.id, location, "myTrash");
+                    wsUtils?.sendMoveCard(stackCard.id, location, "myTrash");
+                });
+                playTrashCardSfx();
+                wsUtils?.sendSfx("playTrashCardSfx");
+                const cardNames = stack
+                    .map((stackCard) => `【${stackCard.isFaceUp ? stackCard.name : "❔"}】`)
+                    .join("");
+                wsUtils?.sendChatMessage(
+                    `[FIELD_UPDATE]≔${cardNames}﹕${convertForLog(location)} ➟ ${convertForLog("myTrash")}`
+                );
+                return;
+            }
+
+            if (!["p", "m"].includes(key) || isTyping || hasModifierKey) return;
             if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
 
             const currentCard = (
@@ -291,9 +323,22 @@ export default function Card(props: CardProps) {
             wsUtils?.sendSfx("playModifyCardSfx");
         };
 
-        document.addEventListener("keydown", changeDpModifier);
-        return () => document.removeEventListener("keydown", changeDpModifier);
-    }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
+        document.addEventListener("keydown", handleSelectedCardShortcut);
+        return () => document.removeEventListener("keydown", handleSelectedCardShortcut);
+    }, [
+        card.cardNumber,
+        card.cardType,
+        card.id,
+        card.name,
+        isDirectlySelected,
+        location,
+        moveCard,
+        playModifyCardSfx,
+        playTrashCardSfx,
+        selectCard,
+        setModifiers,
+        wsUtils,
+    ]);
 
     const inTamerField = tamerLocations.includes(location);
 
@@ -394,7 +439,6 @@ export default function Card(props: CardProps) {
         }
     }
 
-    const selectedCardLocation = getCardLocationById(selectedCard?.id ?? "");
     const locationCardsOfSelected = useGameBoardStates(
         (state) => state[selectedCardLocation as keyof typeof state] as CardTypeGame[]
     );

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -245,6 +245,16 @@ export default function Card(props: CardProps) {
 
     const [renderEffectAnimation, setRenderEffectAnimation] = useState(false);
     const [renderTargetAnimation, setRenderTargetAnimation] = useState(false);
+    const isSelected = selectedCard?.id === card.id;
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const clearSelection = () => selectCard(null);
+        document.addEventListener("click", clearSelection);
+
+        return () => document.removeEventListener("click", clearSelection);
+    }, [isSelected, selectCard]);
 
     const inTamerField = tamerLocations.includes(location);
 
@@ -568,6 +578,10 @@ export default function Card(props: CardProps) {
                             filter: "brightness(0.5) saturate(1.25) hue-rotate(30deg)",
                         }),
                         ...(markedCard === card.id && { outline: "3px solid red" }),
+                        ...(isSelected && {
+                            outline: "3px solid limegreen",
+                            outlineOffset: "-2px",
+                        }),
                     }}
                     className={opponentFieldLocations?.includes(location) ? undefined : "custom-hand-cursor"}
                     onClick={handleClick}


### PR DESCRIPTION
 ## Summary

  Adds selected-card and selected-stack keyboard shortcuts for faster gameplay interactions.

  - Clicking a field card selects its entire stack and displays a green frame.
  - Clicking away clears the selection.
  - "d" moves the entire selected stack to Trash.
  - "b" moves the stack’s top card to Deck Bottom and the remaining cards to Trash.
  - "s" moves the stack’s top card face down to Security Top and the remaining cards to Trash.
  - Token restrictions are respected for Deck and Security actions.
  - Keyboard shortcuts are ignored while typing in form fields.
  - Card movements and modifier changes synchronize with the opponent.
  - Existing sounds and game-log messages are triggered for applicable actions.

  ## Testing

  - Confirmed the frontend production build completes successfully.
  - Tested with Tamers as well. After selecting a tamer and pressing "d" from either tamer side, it still removes the tamer entirely. However, if you press "b" or "s" from the tamer field, it will not bot deck or send the tamer to top of the security. But if you do put the tamer on the digimon field, those same things will still apply. 
  - If you click on the egg digimon from the egg section, the green frame still applys and eggs can be removed that way as well. 
  - Cards from the hand can be selected as well and will show green. Pressing any of the removing buttons will not do anything from the hand at the moment. Maybe we can discuss this in the future for shortcuts for hand interactions.

<img width="1049" height="329" alt="Screenshot 2026-07-15 at 2 08 44 PM" src="https://github.com/user-attachments/assets/c4683064-3e11-4e87-bd75-270f17e5afe3" />

