### PR TITLE
Created Security Stack Shortcut Keys

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -261,15 +261,16 @@ export default function Card(props: CardProps) {
     useEffect(() => {
         if (!isSelected) return;
 
-        const addDpModifier = (event: KeyboardEvent) => {
+        const changeDpModifier = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const isTyping =
                 target instanceof HTMLInputElement ||
                 target instanceof HTMLTextAreaElement ||
                 target instanceof HTMLSelectElement ||
                 target?.isContentEditable;
+            const key = event.key.toLowerCase();
 
-            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (!["p", "m"].includes(key) || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
             if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
 
             const currentCard = (
@@ -279,7 +280,7 @@ export default function Card(props: CardProps) {
 
             const modifiers = {
                 ...currentCard.modifiers,
-                plusDp: currentCard.modifiers.plusDp + 1000,
+                plusDp: currentCard.modifiers.plusDp + (key === "p" ? 1000 : -1000),
             };
 
             setModifiers(card.id, location, modifiers);
@@ -290,8 +291,8 @@ export default function Card(props: CardProps) {
             wsUtils?.sendSfx("playModifyCardSfx");
         };
 
-        document.addEventListener("keydown", addDpModifier);
-        return () => document.removeEventListener("keydown", addDpModifier);
+        document.addEventListener("keydown", changeDpModifier);
+        return () => document.removeEventListener("keydown", changeDpModifier);
     }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -214,6 +214,7 @@ export default function Card(props: CardProps) {
     const setLinkCardInfo = useGameBoardStates((state) => state.setLinkCardInfo);
     const getLinkCardsForLocation = useGameBoardStates((state) => state.getLinkCardsForLocation);
     const setCardToSend = useGameBoardStates((state) => state.setCardToSend);
+    const setModifiers = useGameBoardStates((state) => state.setModifiers);
     const getCardLocationById = useGameBoardStates((state) => state.getCardLocationById);
     const isHandHidden = useGameBoardStates((state) => state.isHandHidden);
     const stackSliceIndex = useGameBoardStates((state) => state.stackSliceIndex);
@@ -232,6 +233,7 @@ export default function Card(props: CardProps) {
 
     const playSuspendSfx = useSound((state) => state.playSuspendSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
+    const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
 
     const cachedImageUrl = useImageCache(card.imgUrl);
     const [cardImageUrl, setCardImageUrl] = useState(cachedImageUrl || card.imgUrl);
@@ -255,6 +257,42 @@ export default function Card(props: CardProps) {
 
         return () => document.removeEventListener("click", clearSelection);
     }, [isSelected, selectCard]);
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const addDpModifier = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            const isTyping =
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target instanceof HTMLSelectElement ||
+                target?.isContentEditable;
+
+            if (event.key.toLowerCase() !== "p" || isTyping || event.ctrlKey || event.metaKey || event.altKey) return;
+            if (card.cardType !== "Digimon" && !numbersWithModifiers.includes(card.cardNumber)) return;
+
+            const currentCard = (
+                useGameBoardStates.getState()[location as keyof ReturnType<typeof useGameBoardStates.getState>] as CardTypeGame[]
+            ).find((locationCard) => locationCard.id === card.id);
+            if (!currentCard) return;
+
+            const modifiers = {
+                ...currentCard.modifiers,
+                plusDp: currentCard.modifiers.plusDp + 1000,
+            };
+
+            setModifiers(card.id, location, modifiers);
+            playModifyCardSfx();
+            wsUtils?.sendMessage(
+                `${wsUtils.matchInfo.gameId}:/setModifiers:${wsUtils.matchInfo.opponentName}:${card.id}:${location}:${JSON.stringify(modifiers)}`
+            );
+            wsUtils?.sendSfx("playModifyCardSfx");
+        };
+
+        document.addEventListener("keydown", addDpModifier);
+        return () => document.removeEventListener("keydown", addDpModifier);
+    }, [card.cardNumber, card.cardType, card.id, isSelected, location, playModifyCardSfx, setModifiers, wsUtils]);
 
     const inTamerField = tamerLocations.includes(location);
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -245,6 +245,16 @@ export default function Card(props: CardProps) {
 
     const [renderEffectAnimation, setRenderEffectAnimation] = useState(false);
     const [renderTargetAnimation, setRenderTargetAnimation] = useState(false);
+    const isSelected = selectedCard?.id === card.id;
+
+    useEffect(() => {
+        if (!isSelected) return;
+
+        const clearSelection = () => selectCard(null);
+        document.addEventListener("click", clearSelection);
+
+        return () => document.removeEventListener("click", clearSelection);
+    }, [isSelected, selectCard]);
 
     const inTamerField = tamerLocations.includes(location);
 
@@ -568,6 +578,10 @@ export default function Card(props: CardProps) {
                             filter: "brightness(0.5) saturate(1.25) hue-rotate(30deg)",
                         }),
                         ...(markedCard === card.id && { outline: "3px solid red" }),
+                        ...(isSelected && {
+                            outline: "3px solid limegreen",
+                            outlineOffset: "-2px",
+                        }),
                     }}
                     className={opponentFieldLocations?.includes(location) ? undefined : "custom-hand-cursor"}
                     onClick={handleClick}

--- a/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
+++ b/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
@@ -42,6 +42,7 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
     const playShuffleDeckSfx = useSound((state) => state.playShuffleDeckSfx);
     const playSecurityRevealSfx = useSound((state) => state.playSecurityRevealSfx);
     const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
+    const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
 
     const isReadyToSendCard = cardToSend && showSecuritySendButtons;
     const isDisabled = bootStage !== BootStage.GAME_IN_PROGRESS;
@@ -93,7 +94,7 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
     useEffect(() => {
         if (!isSecuritySpanHovered || isDisabled) return;
 
-        const sendTopSecurityToTrash = (event: KeyboardEvent) => {
+        const handleSecurityShortcut = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const isTyping =
                 target instanceof HTMLInputElement ||
@@ -101,7 +102,23 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
                 target instanceof HTMLSelectElement ||
                 target?.isContentEditable;
             const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
-            if (event.key.toLowerCase() !== "t" || isTyping || hasModifierKey) return;
+            const key = event.key.toLowerCase();
+            if (!["r", "t"].includes(key) || isTyping || hasModifierKey) return;
+
+            if (key === "r") {
+                const topDeckCard = useGameBoardStates.getState().myDeckField[0];
+                if (!topDeckCard) return;
+
+                event.preventDefault();
+                moveCardToStack("Top", topDeckCard.id, "myDeckField", "mySecurity", "down");
+                playUnsuspendSfx();
+                wsUtils?.sendSfx("playUnsuspendCardSfx");
+                wsUtils?.sendMessage(
+                    `${wsUtils.matchInfo.gameId}:/moveCardToStack:Top:${topDeckCard.id}:myDeckField:mySecurity:down`
+                );
+                wsUtils?.sendChatMessage(`[FIELD_UPDATE]≔【Top Deck Card】﹕➟ Security Top`);
+                return;
+            }
 
             const topCard = useGameBoardStates.getState().mySecurity[0];
             if (!topCard) return;
@@ -116,9 +133,17 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
             wsUtils?.sendSfx("playTrashCardSfx");
         };
 
-        document.addEventListener("keydown", sendTopSecurityToTrash);
-        return () => document.removeEventListener("keydown", sendTopSecurityToTrash);
-    }, [isDisabled, isSecuritySpanHovered, moveCard, playTrashCardSfx, wsUtils]);
+        document.addEventListener("keydown", handleSecurityShortcut);
+        return () => document.removeEventListener("keydown", handleSecurityShortcut);
+    }, [
+        isDisabled,
+        isSecuritySpanHovered,
+        moveCard,
+        moveCardToStack,
+        playTrashCardSfx,
+        playUnsuspendSfx,
+        wsUtils,
+    ]);
 
     const { show: showSecurityStackMenu } = useContextMenu({ id: "securityStackMenu" });
 

--- a/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
+++ b/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
@@ -41,6 +41,7 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
 
     const playShuffleDeckSfx = useSound((state) => state.playShuffleDeckSfx);
     const playSecurityRevealSfx = useSound((state) => state.playSecurityRevealSfx);
+    const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
 
     const isReadyToSendCard = cardToSend && showSecuritySendButtons;
     const isDisabled = bootStage !== BootStage.GAME_IN_PROGRESS;
@@ -87,7 +88,37 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
     const fontSize = useGeneralStates((state) => state.cardWidth / 2.25);
 
     const [isOpen, setIsOpen] = useState(false);
-    8;
+    const [isSecuritySpanHovered, setIsSecuritySpanHovered] = useState(false);
+
+    useEffect(() => {
+        if (!isSecuritySpanHovered || isDisabled) return;
+
+        const sendTopSecurityToTrash = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            const isTyping =
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target instanceof HTMLSelectElement ||
+                target?.isContentEditable;
+            const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
+            if (event.key.toLowerCase() !== "t" || isTyping || hasModifierKey) return;
+
+            const topCard = useGameBoardStates.getState().mySecurity[0];
+            if (!topCard) return;
+
+            event.preventDefault();
+            wsUtils?.sendChatMessage(
+                `[FIELD_UPDATE]≔【${topCard.name}】﹕Security Top ➟ ${convertForLog("myTrash")}`
+            );
+            moveCard(topCard.id, "mySecurity", "myTrash");
+            playTrashCardSfx();
+            wsUtils?.sendMoveCard(topCard.id, "mySecurity", "myTrash");
+            wsUtils?.sendSfx("playTrashCardSfx");
+        };
+
+        document.addEventListener("keydown", sendTopSecurityToTrash);
+        return () => document.removeEventListener("keydown", sendTopSecurityToTrash);
+    }, [isDisabled, isSecuritySpanHovered, moveCard, playTrashCardSfx, wsUtils]);
 
     const { show: showSecurityStackMenu } = useContextMenu({ id: "securityStackMenu" });
 
@@ -146,7 +177,11 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
                         >
                             <CloseIcon />
                         </Button>
-                        <SecuritySpan style={{ fontSize: fontSize * 0.8, pointerEvents: "none" }}>
+                        <SecuritySpan
+                            style={{ fontSize: fontSize * 0.8 }}
+                            onMouseEnter={() => setIsSecuritySpanHovered(true)}
+                            onMouseLeave={() => setIsSecuritySpanHovered(false)}
+                        >
                             {mySecurity.length}
                             <ShieldIcon
                                 style={{
@@ -233,6 +268,8 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
                             style={{ fontSize, cursor: isDisabled ? "not-allowed" : undefined }}
                             className={isDisabled ? undefined : "button"}
                             onClick={() => !isDisabled && sendSecurityReveal()}
+                            onMouseEnter={() => setIsSecuritySpanHovered(true)}
+                            onMouseLeave={() => setIsSecuritySpanHovered(false)}
                             onTouchStart={handleTouchStart}
                             onTouchEnd={handleTouchEnd}
                         >

--- a/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
+++ b/frontend/src/components/game/PlayerBoardSide/PlayerSecurityStack.tsx
@@ -29,6 +29,7 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
     const cardToSend = useGameBoardStates((state) => state.cardToSend);
     const setCardToSend = useGameBoardStates((state) => state.setCardToSend);
     const moveCardToStack = useGameBoardStates((state) => state.moveCardToStack);
+    const flipCard = useGameBoardStates((state) => state.flipCard);
     const cardIdWithEffect = useGameBoardStates((state) => state.cardIdWithEffect);
     const cardIdWithTarget = useGameBoardStates((state) => state.cardIdWithTarget);
     const isEffectInSecurity = mySecurity.find((card) => card.id === cardIdWithEffect) !== undefined;
@@ -103,7 +104,24 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
                 target?.isContentEditable;
             const hasModifierKey = event.ctrlKey || event.metaKey || event.altKey;
             const key = event.key.toLowerCase();
-            if (!["r", "t"].includes(key) || isTyping || hasModifierKey) return;
+            if (!["f", "r", "t"].includes(key) || isTyping || hasModifierKey) return;
+
+            if (key === "f") {
+                const nextFaceDownCard = useGameBoardStates
+                    .getState()
+                    .mySecurity.find((securityCard) => !securityCard.isFaceUp);
+                if (!nextFaceDownCard) return;
+
+                event.preventDefault();
+                flipCard(nextFaceDownCard.id, "mySecurity");
+                wsUtils?.sendMessage(
+                    `${wsUtils.matchInfo.gameId}:/flipCard:${nextFaceDownCard.id}:mySecurity`
+                );
+                wsUtils?.sendChatMessage(
+                    `[FIELD_UPDATE]≔【${nextFaceDownCard.name}】 at ${convertForLog("mySecurity")}﹕➟ Face Up`
+                );
+                return;
+            }
 
             if (key === "r") {
                 const topDeckCard = useGameBoardStates.getState().myDeckField[0];
@@ -138,6 +156,7 @@ export default function PlayerSecurityStack({ wsUtils }: { wsUtils?: WSUtils }) 
     }, [
         isDisabled,
         isSecuritySpanHovered,
+        flipCard,
         moveCard,
         moveCardToStack,
         playTrashCardSfx,


### PR DESCRIPTION
 ## Summary

  Adds hover-based keyboard shortcuts to the player’s Security count.

  While hovering over the Security count:

  - "t" moves the top Security card to Trash.
  - "r" moves the top deck card face down to Security Top.
  - "f" reveals the next face-down Security card, scanning from top to bottom.

  All actions:

  - Support repeated keypresses.
  - Synchronize with the opponent.
  - Add appropriate game-log entries.
  - Preserve hidden deck-card information.
  - Are ignored while typing in form fields.
  - Are disabled before the game starts.

  ## Testing

  - Confirmed the frontend production build completes successfully.
<img width="975" height="223" alt="Screenshot 2026-07-15 at 2 39 34 PM" src="https://github.com/user-attachments/assets/d22563b9-6e57-47ac-b986-4b71aafadb06" />

