### PR TITLE
Assembly feature

### DIFF
--- a/frontend/src/components/game/AssemblyDialog.tsx
+++ b/frontend/src/components/game/AssemblyDialog.tsx
@@ -1,0 +1,156 @@
+import styled from "@emotion/styled";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
+import { handleImageError } from "../../utils/functions.ts";
+import { CardTypeGame } from "../../utils/types.ts";
+
+type Props = {
+    open: boolean;
+    onCancel: () => void;
+    onConfirm: (cards: CardTypeGame[]) => void;
+};
+
+export default function AssemblyDialog({ open, onCancel, onConfirm }: Props) {
+    const myTrash = useGameBoardStates((state) => state.myTrash);
+    const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
+
+    useEffect(() => {
+        if (!open) setSelectedCardIds([]);
+    }, [open]);
+
+    function toggleCard(cardId: string) {
+        setSelectedCardIds((currentIds) =>
+            currentIds.includes(cardId) ? currentIds.filter((id) => id !== cardId) : [...currentIds, cardId]
+        );
+    }
+
+    function handleConfirm() {
+        const selectedCards = selectedCardIds
+            .map((cardId) => myTrash.find((card) => card.id === cardId))
+            .filter((card): card is CardTypeGame => card !== undefined);
+        onConfirm(selectedCards);
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onCancel}
+            fullWidth
+            maxWidth="md"
+            slotProps={{
+                paper: {
+                    sx: {
+                        background: "#173638",
+                        backgroundImage: "linear-gradient(rgba(255,255,255,0.025), rgba(0,0,0,0.06))",
+                        border: "1px solid rgba(210, 210, 190, 0.4)",
+                        color: "ghostwhite",
+                        minHeight: "50vh",
+                        maxHeight: "85vh",
+                    },
+                },
+            }}
+        >
+            <DialogTitle sx={{ fontFamily: "Naston, sans-serif" }}>Assembly</DialogTitle>
+            <DialogContent dividers>
+                <CardGrid>
+                    {myTrash
+                        .slice()
+                        .reverse()
+                        .map((card) => {
+                            const selectionIndex = selectedCardIds.indexOf(card.id);
+                            const isSelected = selectionIndex !== -1;
+
+                            return (
+                                <CardButton
+                                    key={card.id}
+                                    type="button"
+                                    isSelected={isSelected}
+                                    onClick={() => toggleCard(card.id)}
+                                    aria-pressed={isSelected}
+                                    aria-label={`${isSelected ? "Deselect" : "Select"} ${card.name}`}
+                                >
+                                    <CardImage
+                                        src={card.imgUrl}
+                                        alt={`${card.name} ${card.uniqueCardNumber}`}
+                                        onError={handleImageError}
+                                    />
+                                    {isSelected && <SelectionOrder>{selectionIndex + 1}</SelectionOrder>}
+                                </CardButton>
+                            );
+                        })}
+                    {!myTrash.length && <EmptyTrash>Your trash is empty.</EmptyTrash>}
+                </CardGrid>
+            </DialogContent>
+            <DialogActions sx={{ padding: 2 }}>
+                <Button color="inherit" variant="outlined" onClick={onCancel}>
+                    Cancel
+                </Button>
+                <Button variant="contained" disabled={!selectedCardIds.length} onClick={handleConfirm}>
+                    Confirm
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+const CardGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    align-content: start;
+    gap: 14px;
+    min-height: 38vh;
+`;
+
+const CardButton = styled.button<{ isSelected: boolean }>`
+    position: relative;
+    display: block;
+    padding: 0;
+    border: 3px solid ${({ isSelected }) => (isSelected ? "#55d86c" : "transparent")};
+    border-radius: 8px;
+    background: transparent;
+    cursor: pointer;
+    overflow: hidden;
+    transition: border-color 0.12s ease-in-out, transform 0.12s ease-in-out;
+
+    &:hover {
+        transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+        outline: 3px solid dodgerblue;
+        outline-offset: 2px;
+    }
+`;
+
+const CardImage = styled.img`
+    display: block;
+    width: 100%;
+    aspect-ratio: 7 / 10;
+    object-fit: cover;
+`;
+
+const SelectionOrder = styled.span`
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border: 2px solid white;
+    border-radius: 50%;
+    background: #15803d;
+    color: white;
+    font-family: Naston, sans-serif;
+    font-size: 18px;
+    font-weight: 700;
+    box-shadow: 0 2px 5px black;
+`;
+
+const EmptyTrash = styled.p`
+    grid-column: 1 / -1;
+    place-self: center;
+    color: rgba(255, 255, 255, 0.7);
+    font-family: "League Spartan", sans-serif;
+`;

--- a/frontend/src/components/game/AssemblyDialog.tsx
+++ b/frontend/src/components/game/AssemblyDialog.tsx
@@ -1,5 +1,7 @@
 import styled from "@emotion/styled";
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import MinimizeIcon from "@mui/icons-material/Minimize";
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import { useEffect, useState } from "react";
 import { useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
 import { handleImageError } from "../../utils/functions.ts";
@@ -15,9 +17,13 @@ type Props = {
 export default function AssemblyDialog({ open, hasEmptyField, onCancel, onConfirm }: Props) {
     const myTrash = useGameBoardStates((state) => state.myTrash);
     const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
+    const [isMinimized, setIsMinimized] = useState(false);
 
     useEffect(() => {
-        if (!open) setSelectedCardIds([]);
+        if (!open) {
+            setSelectedCardIds([]);
+            setIsMinimized(false);
+        }
     }, [open]);
 
     function toggleCard(cardId: string) {
@@ -34,71 +40,130 @@ export default function AssemblyDialog({ open, hasEmptyField, onCancel, onConfir
     }
 
     return (
-        <Dialog
-            open={open}
-            onClose={onCancel}
-            fullWidth
-            maxWidth="md"
-            slotProps={{
-                paper: {
-                    sx: {
-                        background: "#173638",
-                        backgroundImage: "linear-gradient(rgba(255,255,255,0.025), rgba(0,0,0,0.06))",
-                        border: "1px solid rgba(210, 210, 190, 0.4)",
-                        color: "ghostwhite",
-                        minHeight: "50vh",
-                        maxHeight: "85vh",
+        <>
+            <Dialog
+                open={open && !isMinimized}
+                onClose={(_, reason) => {
+                    if (reason === "backdropClick") {
+                        setIsMinimized(true);
+                        return;
+                    }
+                    onCancel();
+                }}
+                fullWidth
+                maxWidth="md"
+                slotProps={{
+                    paper: {
+                        sx: {
+                            background: "#173638",
+                            backgroundImage: "linear-gradient(rgba(255,255,255,0.025), rgba(0,0,0,0.06))",
+                            border: "1px solid rgba(210, 210, 190, 0.4)",
+                            color: "ghostwhite",
+                            minHeight: "50vh",
+                            maxHeight: "85vh",
+                        },
                     },
-                },
-            }}
-        >
-            <DialogTitle sx={{ fontFamily: "Naston, sans-serif" }}>Assembly</DialogTitle>
-            <DialogContent dividers>
-                <CardGrid>
-                    {myTrash
-                        .slice()
-                        .reverse()
-                        .map((card) => {
-                            const selectionIndex = selectedCardIds.indexOf(card.id);
-                            const isSelected = selectionIndex !== -1;
-
-                            return (
-                                <CardButton
-                                    key={card.id}
-                                    type="button"
-                                    isSelected={isSelected}
-                                    onClick={() => toggleCard(card.id)}
-                                    aria-pressed={isSelected}
-                                    aria-label={`${isSelected ? "Deselect" : "Select"} ${card.name}`}
-                                >
-                                    <CardImage
-                                        src={card.imgUrl}
-                                        alt={`${card.name} ${card.uniqueCardNumber}`}
-                                        onError={handleImageError}
-                                    />
-                                    {isSelected && <SelectionOrder>{selectionIndex + 1}</SelectionOrder>}
-                                </CardButton>
-                            );
-                        })}
-                    {!myTrash.length && <EmptyTrash>Your trash is empty.</EmptyTrash>}
-                </CardGrid>
-            </DialogContent>
-            <DialogActions sx={{ padding: 2 }}>
-                {!hasEmptyField && <FieldWarning>An empty Digimon field is required.</FieldWarning>}
-                <Button color="inherit" variant="outlined" onClick={onCancel}>
-                    Cancel
-                </Button>
-                <Button
-                    variant="contained"
-                    disabled={!selectedCardIds.length || !hasEmptyField}
-                    onClick={handleConfirm}
+                }}
+            >
+                <DialogTitle
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        fontFamily: "Naston, sans-serif",
+                    }}
                 >
-                    Confirm
-                </Button>
-            </DialogActions>
-        </Dialog>
+                    Assembly
+                    <IconButton
+                        aria-label="Minimize Assembly dialog"
+                        title="Minimize"
+                        color="inherit"
+                        onClick={() => setIsMinimized(true)}
+                    >
+                        <MinimizeIcon />
+                    </IconButton>
+                </DialogTitle>
+                <DialogContent dividers>
+                    <CardGrid>
+                        {myTrash
+                            .slice()
+                            .reverse()
+                            .map((card) => {
+                                const selectionIndex = selectedCardIds.indexOf(card.id);
+                                const isSelected = selectionIndex !== -1;
+
+                                return (
+                                    <CardButton
+                                        key={card.id}
+                                        type="button"
+                                        isSelected={isSelected}
+                                        onClick={() => toggleCard(card.id)}
+                                        aria-pressed={isSelected}
+                                        aria-label={`${isSelected ? "Deselect" : "Select"} ${card.name}`}
+                                    >
+                                        <CardImage
+                                            src={card.imgUrl}
+                                            alt={`${card.name} ${card.uniqueCardNumber}`}
+                                            onError={handleImageError}
+                                        />
+                                        {isSelected && <SelectionOrder>{selectionIndex + 1}</SelectionOrder>}
+                                    </CardButton>
+                                );
+                            })}
+                        {!myTrash.length && <EmptyTrash>Your trash is empty.</EmptyTrash>}
+                    </CardGrid>
+                </DialogContent>
+                <DialogActions sx={{ padding: 2 }}>
+                    {!hasEmptyField && <FieldWarning>An empty Digimon field is required.</FieldWarning>}
+                    <Button color="inherit" variant="outlined" onClick={onCancel}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="contained"
+                        disabled={!selectedCardIds.length || !hasEmptyField}
+                        onClick={handleConfirm}
+                    >
+                        Confirm
+                    </Button>
+                </DialogActions>
+            </Dialog>
+            {open && isMinimized && (
+                <>
+                    <InteractionLock aria-hidden="true" onContextMenu={(event) => event.preventDefault()} />
+                    <MinimizedAssemblyButton
+                        variant="contained"
+                        startIcon={<OpenInFullIcon />}
+                        onClick={() => setIsMinimized(false)}
+                    >
+                        Resume Assembly
+                    </MinimizedAssemblyButton>
+                </>
+            )}
+        </>
     );
 }
+
+const InteractionLock = styled.div`
+    position: fixed;
+    inset: 0;
+    z-index: 1299;
+    background: transparent;
+`;
+
+const MinimizedAssemblyButton = styled(Button)`
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 1300;
+    background: #173638;
+    color: ghostwhite;
+    font-family: "Naston", sans-serif;
+    border: 1px solid rgba(210, 210, 190, 0.4);
+
+    &:hover {
+        background: #21494c;
+    }
+`;
 
 const CardGrid = styled.div`
     display: grid;
@@ -117,7 +182,9 @@ const CardButton = styled.button<{ isSelected: boolean }>`
     background: transparent;
     cursor: pointer;
     overflow: hidden;
-    transition: border-color 0.12s ease-in-out, transform 0.12s ease-in-out;
+    transition:
+        border-color 0.12s ease-in-out,
+        transform 0.12s ease-in-out;
 
     &:hover {
         transform: translateY(-2px);

--- a/frontend/src/components/game/AssemblyDialog.tsx
+++ b/frontend/src/components/game/AssemblyDialog.tsx
@@ -7,11 +7,12 @@ import { CardTypeGame } from "../../utils/types.ts";
 
 type Props = {
     open: boolean;
+    hasEmptyField: boolean;
     onCancel: () => void;
     onConfirm: (cards: CardTypeGame[]) => void;
 };
 
-export default function AssemblyDialog({ open, onCancel, onConfirm }: Props) {
+export default function AssemblyDialog({ open, hasEmptyField, onCancel, onConfirm }: Props) {
     const myTrash = useGameBoardStates((state) => state.myTrash);
     const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
 
@@ -83,10 +84,15 @@ export default function AssemblyDialog({ open, onCancel, onConfirm }: Props) {
                 </CardGrid>
             </DialogContent>
             <DialogActions sx={{ padding: 2 }}>
+                {!hasEmptyField && <FieldWarning>An empty Digimon field is required.</FieldWarning>}
                 <Button color="inherit" variant="outlined" onClick={onCancel}>
                     Cancel
                 </Button>
-                <Button variant="contained" disabled={!selectedCardIds.length} onClick={handleConfirm}>
+                <Button
+                    variant="contained"
+                    disabled={!selectedCardIds.length || !hasEmptyField}
+                    onClick={handleConfirm}
+                >
                     Confirm
                 </Button>
             </DialogActions>
@@ -152,5 +158,11 @@ const EmptyTrash = styled.p`
     grid-column: 1 / -1;
     place-self: center;
     color: rgba(255, 255, 255, 0.7);
+    font-family: "League Spartan", sans-serif;
+`;
+
+const FieldWarning = styled.span`
+    margin-right: auto;
+    color: #ffb4ab;
     font-family: "League Spartan", sans-serif;
 `;

--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -15,8 +15,9 @@ import {
     PreviewRounded as StreamerModeIcon,
     LabelImportant as MarkerIcon,
 } from "@mui/icons-material";
-import { CSSProperties } from "react";
+import { CSSProperties, useState } from "react";
 import ModifierMenu from "./ModifierMenu.tsx";
+import AssemblyDialog from "../AssemblyDialog.tsx";
 import { convertForLog, numbersWithModifiers } from "../../../utils/functions.ts";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
 import { tamerLocations, useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
@@ -28,6 +29,7 @@ import { OpenedCardDialog, useGameUIStates } from "../../../hooks/useGameUIState
 
 export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const { sendMessage, sendChatMessage, sendSfx, matchInfo, sendMoveCard } = wsUtils ?? {};
+    const [isAssemblyDialogOpen, setIsAssemblyDialogOpen] = useState(false);
 
     const selectedCard = useGeneralStates((state) => state.selectedCard);
 
@@ -77,7 +79,7 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     }
 
     function handleAssembly() {
-        setOpenedCardDialog(OpenedCardDialog.MY_TRASH);
+        setIsAssemblyDialogOpen(true);
     }
 
     function handleShuffleSecurity() {
@@ -341,6 +343,12 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
                     </div>
                 </Item>
             </StyledMenu>
+
+            <AssemblyDialog
+                open={isAssemblyDialogOpen}
+                onCancel={() => setIsAssemblyDialogOpen(false)}
+                onConfirm={() => setIsAssemblyDialogOpen(false)}
+            />
 
             <StyledMenu id={"opponentHandCardMenu"} theme="dark">
                 <Item onClick={activateTargetAnimation}>

--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -30,6 +30,7 @@ import { OpenedCardDialog, useGameUIStates } from "../../../hooks/useGameUIState
 export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const { sendMessage, sendChatMessage, sendSfx, matchInfo, sendMoveCard } = wsUtils ?? {};
     const [isAssemblyDialogOpen, setIsAssemblyDialogOpen] = useState(false);
+    const [assemblyHandCardId, setAssemblyHandCardId] = useState<string | null>(null);
 
     const selectedCard = useGeneralStates((state) => state.selectedCard);
 
@@ -40,6 +41,11 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const cardToSend = useGameBoardStates((state) => state.cardToSend);
     const mySecurity = useGameBoardStates((state) => state.mySecurity);
     const myDeckField = useGameBoardStates((state) => state.myDeckField);
+    const hasEmptyDigimonField = useGameBoardStates((state) =>
+        Array.from({ length: 16 }, (_, index) => `myDigi${index + 1}`).some(
+            (location) => !(state[location as keyof typeof state] as CardTypeGame[]).length
+        )
+    );
     const shuffleSecurity = useGameBoardStates((state) => state.shuffleSecurity);
     const moveCard = useGameBoardStates((state) => state.moveCard);
     const moveCardToStack = useGameBoardStates((state) => state.moveCardToStack);
@@ -67,6 +73,7 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const playActivateEffectSfx = useSound((state) => state.playActivateEffectSfx);
     const playTargetCardSfx = useSound((state) => state.playTargetCardSfx);
     const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
+    const playPlaceCardSfx = useSound((state) => state.playPlaceCardSfx);
 
     const hasModifierMenu =
         contextCard?.cardType === "Digimon" || numbersWithModifiers.includes(String(contextCard?.cardNumber));
@@ -78,8 +85,42 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
         sendChatMessage?.(`[FIELD_UPDATE]≔【Opened Security】`);
     }
 
-    function handleAssembly() {
+    function handleAssembly({ props }: ItemParams<FieldCardContextMenuItemProps>) {
+        if (!props || props.location !== "myHand") return;
+        setAssemblyHandCardId(props.id);
         setIsAssemblyDialogOpen(true);
+    }
+
+    function closeAssemblyDialog() {
+        setIsAssemblyDialogOpen(false);
+        setAssemblyHandCardId(null);
+    }
+
+    function confirmAssembly(selectedTrashCards: CardTypeGame[]) {
+        if (!assemblyHandCardId || !selectedTrashCards.length) return;
+
+        const boardState = useGameBoardStates.getState();
+        const handCard = boardState.myHand.find((card) => card.id === assemblyHandCardId);
+        const emptyField = Array.from({ length: 16 }, (_, index) => `myDigi${index + 1}`).find(
+            (location) => !(boardState[location as keyof typeof boardState] as CardTypeGame[]).length
+        );
+
+        if (!handCard || !emptyField) return;
+
+        const trashCardsInStackOrder = selectedTrashCards.slice().reverse();
+        trashCardsInStackOrder.forEach((card) => {
+            moveCard(card.id, "myTrash", emptyField);
+            sendMoveCard?.(card.id, "myTrash", emptyField);
+        });
+        moveCard(handCard.id, "myHand", emptyField);
+        sendMoveCard?.(handCard.id, "myHand", emptyField);
+
+        playPlaceCardSfx();
+        sendSfx?.("playPlaceCardSfx");
+        sendChatMessage?.(
+            `[FIELD_UPDATE]≔${trashCardsInStackOrder.map((card) => `【${card.name}】`).join("")}【${handCard.name}】﹕Assembly ➟ ${convertForLog(emptyField)}`
+        );
+        closeAssemblyDialog();
     }
 
     function handleShuffleSecurity() {
@@ -346,8 +387,9 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
 
             <AssemblyDialog
                 open={isAssemblyDialogOpen}
-                onCancel={() => setIsAssemblyDialogOpen(false)}
-                onConfirm={() => setIsAssemblyDialogOpen(false)}
+                hasEmptyField={hasEmptyDigimonField}
+                onCancel={closeAssemblyDialog}
+                onConfirm={confirmAssembly}
             />
 
             <StyledMenu id={"opponentHandCardMenu"} theme="dark">

--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -18,6 +18,7 @@ import {
 import { CSSProperties, useState } from "react";
 import ModifierMenu from "./ModifierMenu.tsx";
 import AssemblyDialog from "../AssemblyDialog.tsx";
+import { assemblyFieldLocations, createAssemblyMoves, findEmptyAssemblyField, isAssemblyCard } from "../assembly.ts";
 import { convertForLog, numbersWithModifiers } from "../../../utils/functions.ts";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
 import { tamerLocations, useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
@@ -42,9 +43,7 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const mySecurity = useGameBoardStates((state) => state.mySecurity);
     const myDeckField = useGameBoardStates((state) => state.myDeckField);
     const hasEmptyDigimonField = useGameBoardStates((state) =>
-        Array.from({ length: 16 }, (_, index) => `myDigi${index + 1}`).some(
-            (location) => !(state[location as keyof typeof state] as CardTypeGame[]).length
-        )
+        assemblyFieldLocations.some((location) => !(state[location as keyof typeof state] as CardTypeGame[]).length)
     );
     const shuffleSecurity = useGameBoardStates((state) => state.shuffleSecurity);
     const moveCard = useGameBoardStates((state) => state.moveCard);
@@ -101,24 +100,22 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
 
         const boardState = useGameBoardStates.getState();
         const handCard = boardState.myHand.find((card) => card.id === assemblyHandCardId);
-        const emptyField = Array.from({ length: 16 }, (_, index) => `myDigi${index + 1}`).find(
-            (location) => !(boardState[location as keyof typeof boardState] as CardTypeGame[]).length
+        const emptyField = findEmptyAssemblyField(
+            (location) => boardState[location as keyof typeof boardState] as CardTypeGame[]
         );
 
         if (!handCard || !emptyField) return;
 
-        const trashCardsInStackOrder = selectedTrashCards.slice().reverse();
-        trashCardsInStackOrder.forEach((card) => {
-            moveCard(card.id, "myTrash", emptyField);
-            sendMoveCard?.(card.id, "myTrash", emptyField);
+        const assemblyMoves = createAssemblyMoves(handCard, selectedTrashCards, emptyField);
+        assemblyMoves.forEach(({ card, from, to }) => {
+            moveCard(card.id, from, to);
+            sendMoveCard?.(card.id, from, to);
         });
-        moveCard(handCard.id, "myHand", emptyField);
-        sendMoveCard?.(handCard.id, "myHand", emptyField);
 
         playPlaceCardSfx();
         sendSfx?.("playPlaceCardSfx");
         sendChatMessage?.(
-            `[FIELD_UPDATE]≔${trashCardsInStackOrder.map((card) => `【${card.name}】`).join("")}【${handCard.name}】﹕Assembly ➟ ${convertForLog(emptyField)}`
+            `[FIELD_UPDATE]≔${assemblyMoves.map(({ card }) => `【${card.name}】`).join("")}﹕Assembly ➟ ${convertForLog(emptyField)}`
         );
         closeAssemblyDialog();
     }
@@ -274,11 +271,13 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
                         <StreamerModeIcon />
                     </div>
                 </Item>
-                <Item onClick={handleAssembly}>
-                    <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
-                        <span>Assembly</span>
-                    </div>
-                </Item>
+                {isAssemblyCard(contextCard) && (
+                    <Item onClick={handleAssembly}>
+                        <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+                            <span>Assembly</span>
+                        </div>
+                    </Item>
+                )}
             </StyledMenu>
 
             <StyledMenu id={"fieldCardMenu"} theme="dark">

--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -76,6 +76,10 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
         sendChatMessage?.(`[FIELD_UPDATE]≔【Opened Security】`);
     }
 
+    function handleAssembly() {
+        setOpenedCardDialog(OpenedCardDialog.MY_TRASH);
+    }
+
     function handleShuffleSecurity() {
         shuffleSecurity();
         playShuffleDeckSfx();
@@ -225,6 +229,11 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
                     <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
                         <span>{isHandHidden ? "Disable Stream Mode" : "Activate Stream Mode"}</span>
                         <StreamerModeIcon />
+                    </div>
+                </Item>
+                <Item onClick={handleAssembly}>
+                    <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+                        <span>Assembly</span>
                     </div>
                 </Item>
             </StyledMenu>

--- a/frontend/src/components/game/assembly.ts
+++ b/frontend/src/components/game/assembly.ts
@@ -1,0 +1,21 @@
+import { CardTypeGame } from "../../utils/types.ts";
+
+export const assemblyFieldLocations = Array.from({ length: 16 }, (_, index) => `myDigi${index + 1}`);
+
+export function isAssemblyCard(card?: CardTypeGame) {
+    return card?.cardType.includes("Digimon") ?? false;
+}
+
+export function findEmptyAssemblyField(getCards: (location: string) => CardTypeGame[]) {
+    return assemblyFieldLocations.find((location) => !getCards(location).length);
+}
+
+export function createAssemblyMoves(handCard: CardTypeGame, selectedTrashCards: CardTypeGame[], to: string) {
+    return [
+        ...selectedTrashCards
+            .slice()
+            .reverse()
+            .map((card) => ({ card, from: "myTrash", to })),
+        { card: handCard, from: "myHand", to },
+    ];
+}


### PR DESCRIPTION
 ## PR Summary

  Adds the new Assembly workflow for Digimon cards in the player’s hand.

  ### Changes

  - Adds an Assembly option when right-clicking Digimon-type hand cards.
  - Opens a centered dialog displaying cards from the player’s trash.
  - Supports ordered card selection with numbered indicators.
  - Renumbers selections when a card is deselected.
  - Provides Confirm and Cancel actions.
  - Disables Confirm until cards are selected and an empty Digimon field exists.
  - Places selected trash cards into the first empty Digimon field in the correct stack order.
  - Places the originating hand card on top of the assembled stack.
  - Synchronizes Assembly movements over WebSocket.
  - Adds placement sound and field-update logging.
  - Adds an empty-trash state and no-available-field warning.

  ### Testing

  Adds 11 tests covering menu visibility, selection behavior, validation, field placement, stack ordering, and hand-card positioning.

  All tests and TypeScript validation pass.

Players now have a new option to use the Assembly button by right clicking a Digimon card from their hand.
<img width="913" height="436" alt="Screenshot 2026-07-16 at 11 36 38 AM" src="https://github.com/user-attachments/assets/6c07d94b-c966-43ee-bb87-62ef34f96ee7" />
It opens a dialog from which the player can choose the order of cards to be in the Digivolution stack.
<img width="951" height="501" alt="Screenshot 2026-07-16 at 11 37 20 AM" src="https://github.com/user-attachments/assets/f067e039-3dbe-4350-bd04-1fd42d08dad9" />
The placement of the newly assembled Digimon should be on an empty field from the Digimon field.
<img width="1139" height="298" alt="Screenshot 2026-07-16 at 11 37 28 AM" src="https://github.com/user-attachments/assets/5700f4c2-04e1-4b6d-a14c-5268d2034a7e" />
<img width="1089" height="332" alt="Screenshot 2026-07-16 at 11 43 38 AM" src="https://github.com/user-attachments/assets/02ba1a1d-c619-46bc-a482-c1f4c3157e46" />

Added Assembly dialog minimize functionality, the user's action will be locked until they either confirm or cancel on assembly:
<img width="1029" height="623" alt="Screenshot 2026-07-18 at 11 27 33 AM" src="https://github.com/user-attachments/assets/7e399fd2-e461-4f21-ad3b-94b1fee5b2b2" />

<img width="1252" height="440" alt="Screenshot 2026-07-18 at 11 27 47 AM" src="https://github.com/user-attachments/assets/ddb559ed-0ce0-4bdf-95ac-1411ab3fa1a0" />
