### PR TITLE
Fix dual card description

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/CardService.java
+++ b/backend/src/main/java/com/github/wekaito/backend/CardService.java
@@ -59,6 +59,7 @@ public class CardService {
             null,
             null,
             null,
+            null,
             new Restrictions("","","",""),
             null
     );
@@ -153,6 +154,7 @@ public class CardService {
                         (card.playCost().equals("-")) ? null : safeParseInt(card.playCost()),
                         (card.cardLv().equals("-")) ? null : safeParseInt(card.cardLv().split("\\.")[1]),
                         (card.effect().equals("-")) ? null : card.effect(),
+                        (card.optionCardEffect() == null || card.optionCardEffect().equals("-")) ? null : card.optionCardEffect(),
                         (card.digivolveEffect().equals("-")) ? null : card.digivolveEffect(),
                         (card.aceEffect().equals("-")) ? null : card.aceEffect(),
                         (card.burstDigivolve().equals("-")) ? null : card.burstDigivolve(),

--- a/backend/src/main/java/com/github/wekaito/backend/models/Card.java
+++ b/backend/src/main/java/com/github/wekaito/backend/models/Card.java
@@ -18,6 +18,7 @@ public record Card(
         Integer playCost,
         Integer level,
         String mainEffect,
+        String optionCardEffect,
         String inheritedEffect,
         String aceEffect,
         String burstDigivolve,
@@ -35,4 +36,3 @@ public record Card(
 ) {
 
 }
-

--- a/backend/src/main/java/com/github/wekaito/backend/models/FetchCard.java
+++ b/backend/src/main/java/com/github/wekaito/backend/models/FetchCard.java
@@ -18,6 +18,7 @@ public record FetchCard(
         String playCost,
         String cardLv,
         String effect,
+        String optionCardEffect,
         String digivolveEffect,
         String aceEffect,
         String burstDigivolve,

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/CardJsonConverter.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/CardJsonConverter.java
@@ -42,6 +42,7 @@ public class CardJsonConverter {
         Integer playCost = getIntegerField(cardNode, "playCost");
         Integer level = getIntegerField(cardNode, "level");
         String mainEffect = getStringField(cardNode, "mainEffect", null);
+        String optionCardEffect = getStringField(cardNode, "optionCardEffect", null);
         String inheritedEffect = getStringField(cardNode, "inheritedEffect", null);
         String aceEffect = getStringField(cardNode, "aceEffect", null);
         String burstDigivolve = getStringField(cardNode, "burstDigivolve", null);
@@ -79,6 +80,7 @@ public class CardJsonConverter {
                 .playCost(playCost)
                 .level(level)
                 .mainEffect(mainEffect)
+                .optionCardEffect(optionCardEffect)
                 .inheritedEffect(inheritedEffect)
                 .aceEffect(aceEffect)
                 .burstDigivolve(burstDigivolve)

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameCard.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameCard.java
@@ -28,6 +28,7 @@ public class GameCard {
     public Integer playCost;
     public Integer level;
     public String mainEffect;
+    public String optionCardEffect;
     public String inheritedEffect;
     public String aceEffect;
     public String burstDigivolve;
@@ -53,4 +54,3 @@ public class GameCard {
         this.isFaceUp = !this.isFaceUp;
     }
 }
-

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameRoom.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameRoom.java
@@ -132,6 +132,7 @@ public class GameRoom {
                     .playCost(card.playCost())
                     .level(card.level())
                     .mainEffect(card.mainEffect())
+                    .optionCardEffect(card.optionCardEffect())
                     .inheritedEffect(card.inheritedEffect())
                     .aceEffect(card.aceEffect())
                     .burstDigivolve(card.burstDigivolve())

--- a/frontend/src/components/cardDetails/CardDetails.tsx
+++ b/frontend/src/components/cardDetails/CardDetails.tsx
@@ -97,6 +97,7 @@ export default function CardDetails() {
 
     const name = hoverCard?.name ?? selectedCard?.name;
     const cardType = hoverCard?.cardType ?? selectedCard?.cardType;
+    const isOptionCard = cardType?.split("/").includes("Option") ?? false;
 
     const isNameLong = Boolean(
         hoverCard ? hoverCard.name?.length >= 30 : selectedCard && selectedCard?.name.length >= 30
@@ -269,7 +270,7 @@ export default function CardDetails() {
                         >
                             {cardType !== "Digi-Egg" && (
                                 <DetailText>
-                                    {cardType === "Option" ? "Use: " : "Play: "}
+                                    {isOptionCard ? "Use: " : "Play: "}
                                     <DetailMetric>{playCost}</DetailMetric>
                                 </DetailText>
                             )}

--- a/frontend/src/components/cardDetails/CardDetails.tsx
+++ b/frontend/src/components/cardDetails/CardDetails.tsx
@@ -95,6 +95,8 @@ export default function CardDetails() {
 
     // effect texts
     const mainEffectText = hoverCard?.mainEffect ?? (!hoverCard ? (selectedCard?.mainEffect ?? "") : "");
+    const optionCardEffectText =
+        hoverCard?.optionCardEffect ?? (!hoverCard ? (selectedCard?.optionCardEffect ?? "") : "");
     const inheritedEffectText = hoverCard?.inheritedEffect ?? (!hoverCard ? (selectedCard?.inheritedEffect ?? "") : "");
     const securityEffectText = hoverCard?.securityEffect ?? (!hoverCard ? (selectedCard?.securityEffect ?? "") : "");
     const specialDigivolveText =
@@ -320,6 +322,12 @@ export default function CardDetails() {
                         {mainEffectText && (
                             <EffectCard variant={EffectVariant.MAIN} key={`${cardNumber}_main`}>
                                 <HighlightedKeyWords text={mainEffectText} />
+                            </EffectCard>
+                        )}
+
+                        {optionCardEffectText && (
+                            <EffectCard variant={EffectVariant.OPTION} key={`${cardNumber}_option`}>
+                                <HighlightedKeyWords text={optionCardEffectText} />
                             </EffectCard>
                         )}
 

--- a/frontend/src/components/cardDetails/CardDetails.tsx
+++ b/frontend/src/components/cardDetails/CardDetails.tsx
@@ -83,6 +83,17 @@ export default function CardDetails() {
     const inheritCardInfo = useGameBoardStates((state) => state.inheritCardInfo);
     const linkCardInfo = useGameBoardStates((state) => state.linkCardInfo);
     const details = useSettingStates((state) => state.details);
+    const displayedCardId = hoverCard?.id ?? selectedCard?.id ?? "";
+    const isInDigimonStack = useGameBoardStates((state) => {
+        if (!displayedCardId) return false;
+
+        const cardLocation = state.getCardLocationById(displayedCardId);
+        const isDigimonBattleArea = /^(?:my|opponent)Digi(?:[1-9]|1[0-6])$/.test(cardLocation);
+        if (!isDigimonBattleArea) return false;
+
+        const cardsAtLocation = state[cardLocation as keyof typeof state];
+        return Array.isArray(cardsAtLocation) && cardsAtLocation.length > 1;
+    });
 
     const name = hoverCard?.name ?? selectedCard?.name;
     const cardType = hoverCard?.cardType ?? selectedCard?.cardType;
@@ -325,7 +336,7 @@ export default function CardDetails() {
                             </EffectCard>
                         )}
 
-                        {optionCardEffectText && (
+                        {optionCardEffectText && !isInDigimonStack && (
                             <EffectCard variant={EffectVariant.OPTION} key={`${cardNumber}_option`}>
                                 <HighlightedKeyWords text={optionCardEffectText} />
                             </EffectCard>

--- a/frontend/src/components/cardDetails/EffectVariant.ts
+++ b/frontend/src/components/cardDetails/EffectVariant.ts
@@ -1,5 +1,6 @@
 export enum EffectVariant {
     MAIN = "main",
+    OPTION = "option",
     INHERITED = "inherited",
     SECURITY = "security",
     SPECIAL = "special",

--- a/frontend/src/hooks/useGeneralStates.ts
+++ b/frontend/src/hooks/useGeneralStates.ts
@@ -25,7 +25,7 @@ type State = {
 
     selectedCard: CardTypeWithId | CardTypeGame | null;
     selectCard: (card: CardTypeWithId | CardTypeGame | null) => void;
-    hoverCard: CardTypeWithId | null;
+    hoverCard: CardTypeWithId | CardTypeGame | null;
     setHoverCard: (card: CardTypeWithId | CardTypeGame | null) => void;
 
     user: string;
@@ -80,7 +80,9 @@ export const useGeneralStates = create<State>((set, get) => ({
 
     selectCard: (card) => set({ selectedCard: card }),
 
-    setHoverCard: (card) => set({ hoverCard: card }),
+    setHoverCard: (card) => {
+        set({ hoverCard: card });
+    },
 
     login: (userName: string, password: string, navigate: NavigateFunction) => {
         axios

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -14,6 +14,7 @@ export type CardType = {
     playCost?: number;
     level?: number;
     mainEffect?: string;
+    optionCardEffect?: string;
     inheritedEffect?: string;
     aceEffect?: string;
     burstDigivolve?: string;


### PR DESCRIPTION
• ## PR Summary

  Adds complete hover-detail support for dual Digimon/Option cards.

  ### Changes

  - Adds the upstream optionCardEffect property across:
      - Backend card-fetch model
      - Persisted card model
      - WebSocket game-card model
      - Frontend card types

  - Preserves optionCardEffect when constructing and converting game cards.
  - Displays the Option-side text in a separate “OPTION EFFECT” section.
  - Hides the Option Effect when the card is part of a Digimon stack.
  - Continues displaying the Option Effect when the card is standalone or outside the battle area.
  - Displays Digimon/Option card costs as “Use” instead of “Play.”
  - Updates hover-card typing to support complete in-game card data.

  ### Validation

  - Backend clean compilation passes.
  - No new frontend TypeScript errors were introduced.
  - Existing unrelated Lobby.tsx type errors remain.

When a dual card is digivolved on top of a stack, the option information is hidden. When the card is a standalone option on the digimon field, players can hover over and see the option information
<img width="961" height="570" alt="Screenshot 2026-07-17 at 1 37 54 PM" src="https://github.com/user-attachments/assets/e58edc35-a00d-4d82-a10f-671b93fe7523" />
Dual cards do not have a play cost so players only see a Use cost on hover.
<img width="340" height="67" alt="Screenshot 2026-07-17 at 1 38 08 PM" src="https://github.com/user-attachments/assets/612aca64-845c-489f-9541-6752d6e325d7" />
When hovering during deck building mode, players can now see the option effect information
<img width="396" height="611" alt="Screenshot 2026-07-17 at 1 27 46 PM" src="https://github.com/user-attachments/assets/a9a036ca-0881-4bf7-9a2d-257fb8caea3d" />
