### PR TITLE
Rework Open Stack Functionality

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -173,10 +173,11 @@ type CardProps = {
     setImageError?: (imageError: boolean) => void;
     style?: CSSProperties;
     onContextMenu?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    disableDragging?: boolean;
 };
 
 export default function Card(props: CardProps) {
-    const { card, location, index, setImageError, style, onContextMenu, wsUtils } = props;
+    const { card, location, index, setImageError, style, onContextMenu, wsUtils, disableDragging = false } = props;
 
     const username = useGeneralStates((state) => state.user);
     const cardWidth = useGeneralStates((state) => state.cardWidth);
@@ -268,12 +269,12 @@ export default function Card(props: CardProps) {
                 type: "card",
                 content: { location, card },
             },
-            canDrag: !opponentFieldLocations.includes(location) && gameHasStarted,
+            canDrag: !disableDragging && !opponentFieldLocations.includes(location) && gameHasStarted,
             collect: (monitor) => ({
                 isDragging: monitor.isDragging(),
             }),
         }),
-        [location, card, opponentFieldLocations, gameHasStarted]
+        [location, card, disableDragging, opponentFieldLocations, gameHasStarted]
     );
 
     // Separate drag logic for stack icon - always drags as card-stack
@@ -288,7 +289,8 @@ export default function Card(props: CardProps) {
                 type: "card-stack",
                 content: { location, cards: stackCards },
             },
-            canDrag: !opponentFieldLocations.includes(location) && stackDraggedLocation === null,
+            canDrag:
+                !disableDragging && !opponentFieldLocations.includes(location) && stackDraggedLocation === null,
             end: () => {
                 setStackSliceIndex(0);
                 setStackDragIcon(null);
@@ -298,7 +300,7 @@ export default function Card(props: CardProps) {
                 isDragging: monitor.isDragging(),
             }),
         };
-    }, [location, locationCards, index, inTamerField, opponentFieldLocations]);
+    }, [location, locationCards, index, inTamerField, disableDragging, opponentFieldLocations]);
 
     useEffect(() => setStackDraggedLocation(isStackDragging ? location : null), [isStackDragging]);
 
@@ -464,6 +466,7 @@ export default function Card(props: CardProps) {
                 {((index !== 0 && (myDigimonLocations.includes(location) || location === "myBreedingArea")) ||
                     (index !== locationCards.length - 1 && myTamerLocations.includes(location))) &&
                     (isHovered || isDragIconHovered || hoveredId === card.id) &&
+                    !disableDragging &&
                     !useToggleForStacks && (
                         <DragStackIconDiv
                             ref={stackDragRef as any}

--- a/frontend/src/components/game/StackDialog.tsx
+++ b/frontend/src/components/game/StackDialog.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { LibraryAddCheckTwoTone as SelectStackIcon } from "@mui/icons-material";
 import { useContextMenu } from "react-contexify";
 import { useEffect, useState } from "react";
 import Card from "../Card.tsx";
@@ -47,6 +48,13 @@ export default function StackDialog({ wsUtils }: { wsUtils?: WSUtils }) {
         setSelectedCardIds((currentIds) =>
             currentIds.includes(cardId) ? currentIds.filter((id) => id !== cardId) : [...currentIds, cardId]
         );
+    }
+
+    function selectCardAndFollowing(cardId: string) {
+        if (!isOwnStack) return;
+        const cardIndex = cardsToRender.findIndex((card) => card.id === cardId);
+        if (cardIndex === -1) return;
+        setSelectedCardIds(cardsToRender.slice(cardIndex).map((card) => card.id));
     }
 
     function trashSelectedCards() {
@@ -100,7 +108,10 @@ export default function StackDialog({ wsUtils }: { wsUtils?: WSUtils }) {
                                 key={card.id}
                                 isSelected={isSelected}
                                 isSelectable={isOwnStack}
-                                onClickCapture={() => toggleCard(card.id)}
+                                onClickCapture={(event) => {
+                                    if ((event.target as Element).closest("[data-select-stack]")) return;
+                                    toggleCard(card.id);
+                                }}
                                 onKeyDown={(event) => {
                                     if (event.key === "Enter" || event.key === " ") toggleCard(card.id);
                                 }}
@@ -114,6 +125,7 @@ export default function StackDialog({ wsUtils }: { wsUtils?: WSUtils }) {
                                     location={stackDialog}
                                     style={{ width: "100%" }}
                                     index={index}
+                                    disableDragging
                                     onContextMenu={(event) =>
                                         showCardMenu({
                                             event,
@@ -126,6 +138,20 @@ export default function StackDialog({ wsUtils }: { wsUtils?: WSUtils }) {
                                         })
                                     }
                                 />
+                                {isOwnStack && (
+                                    <SelectFollowingButton
+                                        type="button"
+                                        data-select-stack
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+                                            selectCardAndFollowing(card.id);
+                                        }}
+                                        aria-label={`Select ${card.name} and all cards beneath it`}
+                                        title="Select this card and all cards beneath it"
+                                    >
+                                        <SelectStackIcon sx={{ fontSize: 25 }} />
+                                    </SelectFollowingButton>
+                                )}
                                 {isSelected && <SelectionOrder>{selectionIndex + 1}</SelectionOrder>}
                             </CardContainer>
                         );
@@ -192,4 +218,29 @@ const SelectionOrder = styled.span`
     font-weight: 700;
     box-shadow: 0 2px 5px black;
     pointer-events: none;
+`;
+
+const SelectFollowingButton = styled.button`
+    position: absolute;
+    right: 5px;
+    bottom: 5px;
+    z-index: 4;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    border: 1px solid rgba(255, 255, 255, 0.75);
+    border-radius: 4px;
+    background: rgba(12, 21, 16, 0.82);
+    color: ghostwhite;
+    cursor: pointer;
+
+    &:hover {
+        background: rgba(65, 135, 211, 0.92);
+    }
+
+    &:focus-visible {
+        outline: 3px solid dodgerblue;
+        outline-offset: 2px;
+    }
 `;

--- a/frontend/src/components/game/StackDialog.tsx
+++ b/frontend/src/components/game/StackDialog.tsx
@@ -1,15 +1,14 @@
 import styled from "@emotion/styled";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { useContextMenu } from "react-contexify";
+import { useEffect } from "react";
 import Card from "../Card.tsx";
 import { tamerLocations, useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
-import { useGeneralStates } from "../../hooks/useGeneralStates.ts";
-import { CardTypeGame } from "../../utils/types.ts";
-import { useContextMenu } from "react-contexify";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useGameUIStates } from "../../hooks/useGameUIStates.ts";
+import { CardTypeGame } from "../../utils/types.ts";
 
 /**
- * Dialog that shows the stack of cards in a location and closes automatically if the trash or security is opened.
- * It is only an alternative display of the cards in the location and similar to the CardDialog but maintains stack-dragging functionality.
+ * Displays all cards in a field stack in a centered dialog.
  */
 export default function StackDialog() {
     const stackDialog = useGameUIStates((state) => state.stackDialog);
@@ -19,71 +18,88 @@ export default function StackDialog() {
         stackDialog ? (state[stackDialog as keyof typeof state] as CardTypeGame[]) : []
     );
 
-    const cardWidth = useGeneralStates((state) => state.cardWidth);
-
-    const containerRef = useRef<HTMLDivElement>(null);
-    const [width, setWidth] = useState(cardWidth);
-
-    const reverse = !(!!stackDialog && tamerLocations.includes(stackDialog));
-
     const { show: showCardMenu } = useContextMenu({
         id: stackDialog !== false && stackDialog.includes("opponent") ? "dialogMenuOpponent" : "dialogMenu",
         props: { index: -1, location: "", id: "" },
     });
 
-    useLayoutEffect(() => {
-        if (containerRef.current) setWidth(containerRef.current.clientWidth / 4.4); //3.25 = 3 cards; 4.4 = 4 cards
-    }, [containerRef.current?.clientWidth]);
-
     useEffect(() => {
-        if (stackDialog && !locationCards.length) setStackDialog(false); // correctly close the dialog if there are no cards
+        if (stackDialog && !locationCards.length) setStackDialog(false);
     }, [locationCards, stackDialog, setStackDialog]);
 
-    if (!stackDialog) return <></>;
+    if (!stackDialog) return null;
+
+    const cardsToRender = tamerLocations.includes(stackDialog)
+        ? locationCards
+        : locationCards.slice().reverse();
 
     return (
-        <Container
-            reverse={reverse}
-            ref={containerRef}
-            id={stackDialog + "_stackModal"}
-            onMouseOver={(e) => e.stopPropagation()}
+        <Dialog
+            open
+            onClose={() => setStackDialog(false)}
+            fullWidth
+            maxWidth="md"
+            slotProps={{
+                paper: {
+                    sx: {
+                        background: "#173638",
+                        backgroundImage: "linear-gradient(rgba(255,255,255,0.025), rgba(0,0,0,0.06))",
+                        border: "1px solid rgba(210, 210, 190, 0.4)",
+                        color: "ghostwhite",
+                        minHeight: "50vh",
+                        maxHeight: "85vh",
+                    },
+                },
+            }}
         >
-            {locationCards.map((card, index) => (
-                <Card
-                    card={card}
-                    location={stackDialog}
-                    style={{ width }}
-                    key={card.id}
-                    index={index}
-                    onContextMenu={(e) => {
-                        showCardMenu?.({
-                            event: e,
-                            props: { index, location: stackDialog, id: card.id, name: card.name },
-                        });
-                    }}
-                />
-            ))}
-        </Container>
+            <DialogTitle sx={{ fontFamily: "Naston, sans-serif" }}>Show Stack</DialogTitle>
+            <DialogContent dividers>
+                <CardGrid>
+                    {cardsToRender.map((card) => {
+                        const index = locationCards.findIndex((locationCard) => locationCard.id === card.id);
+                        return (
+                            <CardContainer key={card.id}>
+                                <Card
+                                    card={card}
+                                    location={stackDialog}
+                                    style={{ width: "100%" }}
+                                    index={index}
+                                    onContextMenu={(event) =>
+                                        showCardMenu({
+                                            event,
+                                            props: {
+                                                index,
+                                                location: stackDialog,
+                                                id: card.id,
+                                                name: card.name,
+                                            },
+                                        })
+                                    }
+                                />
+                            </CardContainer>
+                        );
+                    })}
+                </CardGrid>
+            </DialogContent>
+            <DialogActions sx={{ padding: 2 }}>
+                <Button color="inherit" variant="outlined" onClick={() => setStackDialog(false)}>
+                    Close
+                </Button>
+            </DialogActions>
+        </Dialog>
     );
 }
 
-const Container = styled.div<{ reverse: boolean }>`
+const CardGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    align-content: start;
+    gap: 14px;
+    min-height: 38vh;
+`;
+
+const CardContainer = styled.div`
     position: relative;
     width: 100%;
-    flex: 1;
-    padding: 6px 4px 6px 6px;
-    display: flex;
-    flex-flow: ${({ reverse }) => (reverse ? "row-reverse wrap-reverse" : "row wrap")};
-    place-content: ${({ reverse }) => (reverse ? "flex-start" : "flex-end")};
-    gap: 1.5%;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    border-radius: 3px;
-
-    scrollbar-width: none;
-
-    ::-webkit-scrollbar {
-        visibility: hidden;
-        width: 0;
-    }
+    aspect-ratio: 7 / 9.75;
 `;

--- a/frontend/src/components/game/StackDialog.tsx
+++ b/frontend/src/components/game/StackDialog.tsx
@@ -1,18 +1,23 @@
 import styled from "@emotion/styled";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
 import { useContextMenu } from "react-contexify";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Card from "../Card.tsx";
 import { tamerLocations, useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
 import { useGameUIStates } from "../../hooks/useGameUIStates.ts";
+import { useSound } from "../../hooks/useSound.ts";
 import { CardTypeGame } from "../../utils/types.ts";
+import type { WSUtils } from "../../pages/GamePage.tsx";
 
 /**
  * Displays all cards in a field stack in a centered dialog.
  */
-export default function StackDialog() {
+export default function StackDialog({ wsUtils }: { wsUtils?: WSUtils }) {
     const stackDialog = useGameUIStates((state) => state.stackDialog);
     const setStackDialog = useGameUIStates((state) => state.setStackDialog);
+    const moveCard = useGameBoardStates((state) => state.moveCard);
+    const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
+    const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
 
     const locationCards = useGameBoardStates((state) =>
         stackDialog ? (state[stackDialog as keyof typeof state] as CardTypeGame[]) : []
@@ -27,11 +32,42 @@ export default function StackDialog() {
         if (stackDialog && !locationCards.length) setStackDialog(false);
     }, [locationCards, stackDialog, setStackDialog]);
 
+    useEffect(() => setSelectedCardIds([]), [stackDialog]);
+
     if (!stackDialog) return null;
+
+    const isOwnStack = stackDialog.startsWith("my");
 
     const cardsToRender = tamerLocations.includes(stackDialog)
         ? locationCards
         : locationCards.slice().reverse();
+
+    function toggleCard(cardId: string) {
+        if (!isOwnStack) return;
+        setSelectedCardIds((currentIds) =>
+            currentIds.includes(cardId) ? currentIds.filter((id) => id !== cardId) : [...currentIds, cardId]
+        );
+    }
+
+    function trashSelectedCards() {
+        if (!stackDialog || !isOwnStack || !selectedCardIds.length) return;
+
+        const selectedCards = selectedCardIds
+            .map((cardId) => locationCards.find((card) => card.id === cardId))
+            .filter((card): card is CardTypeGame => card !== undefined);
+
+        selectedCards.forEach((card) => {
+            moveCard(card.id, stackDialog, "myTrash");
+            wsUtils?.sendMoveCard(card.id, stackDialog, "myTrash");
+        });
+
+        playTrashCardSfx();
+        wsUtils?.sendSfx("playTrashCardSfx");
+        wsUtils?.sendChatMessage(
+            `[FIELD_UPDATE]≔${selectedCards.map((card) => `【${card.name}】`).join("")}﹕Stack ➟ Trash`
+        );
+        setStackDialog(false);
+    }
 
     return (
         <Dialog
@@ -57,8 +93,22 @@ export default function StackDialog() {
                 <CardGrid>
                     {cardsToRender.map((card) => {
                         const index = locationCards.findIndex((locationCard) => locationCard.id === card.id);
+                        const selectionIndex = selectedCardIds.indexOf(card.id);
+                        const isSelected = selectionIndex !== -1;
                         return (
-                            <CardContainer key={card.id}>
+                            <CardContainer
+                                key={card.id}
+                                isSelected={isSelected}
+                                isSelectable={isOwnStack}
+                                onClickCapture={() => toggleCard(card.id)}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter" || event.key === " ") toggleCard(card.id);
+                                }}
+                                role={isOwnStack ? "button" : undefined}
+                                tabIndex={isOwnStack ? 0 : undefined}
+                                aria-pressed={isOwnStack ? isSelected : undefined}
+                                aria-label={isOwnStack ? `${isSelected ? "Deselect" : "Select"} ${card.name}` : undefined}
+                            >
                                 <Card
                                     card={card}
                                     location={stackDialog}
@@ -76,15 +126,21 @@ export default function StackDialog() {
                                         })
                                     }
                                 />
+                                {isSelected && <SelectionOrder>{selectionIndex + 1}</SelectionOrder>}
                             </CardContainer>
                         );
                     })}
                 </CardGrid>
             </DialogContent>
-            <DialogActions sx={{ padding: 2 }}>
+            <DialogActions sx={{ padding: 2, gap: 1 }}>
                 <Button color="inherit" variant="outlined" onClick={() => setStackDialog(false)}>
                     Close
                 </Button>
+                {isOwnStack && (
+                    <Button color="error" variant="contained" disabled={!selectedCardIds.length} onClick={trashSelectedCards}>
+                        Trash
+                    </Button>
+                )}
             </DialogActions>
         </Dialog>
     );
@@ -98,8 +154,42 @@ const CardGrid = styled.div`
     min-height: 38vh;
 `;
 
-const CardContainer = styled.div`
+const CardContainer = styled.div<{ isSelected: boolean; isSelectable: boolean }>`
     position: relative;
     width: 100%;
     aspect-ratio: 7 / 9.75;
+    box-sizing: border-box;
+    border: 3px solid ${({ isSelected }) => (isSelected ? "#55d86c" : "transparent")};
+    border-radius: 8px;
+    cursor: ${({ isSelectable }) => (isSelectable ? "pointer" : "default")};
+    transition: border-color 0.12s ease-in-out, transform 0.12s ease-in-out;
+
+    &:hover {
+        transform: ${({ isSelectable }) => (isSelectable ? "translateY(-2px)" : "none")};
+    }
+
+    &:focus-visible {
+        outline: 3px solid dodgerblue;
+        outline-offset: 2px;
+    }
+`;
+
+const SelectionOrder = styled.span`
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 5;
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border: 2px solid white;
+    border-radius: 50%;
+    background: #15803d;
+    color: white;
+    font-family: Naston, sans-serif;
+    font-size: 18px;
+    font-weight: 700;
+    box-shadow: 0 2px 5px black;
+    pointer-events: none;
 `;

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -220,7 +220,7 @@ export default function GamePage() {
             <ChatAndCardDialogContainerDiv>
                 {!stackDialog && !openedCardDialog && <GameChatLog {...wsUtils} />}
                 {!!openedCardDialog && <CardDialog />}
-                {!!stackDialog && <StackDialog />}
+                {!!stackDialog && <StackDialog wsUtils={wsUtils} />}
             </ChatAndCardDialogContainerDiv>
 
             <RevealArea />


### PR DESCRIPTION
• ## PR Summary

  Reworks the field stack viewer into an interactive, centered dialog.

  ### Changes

  - Replaces the inline “Show Stack” view with a centered MUI dialog.
  - Displays stack cards in a responsive grid and in stack order.
  - Preserves card hover details, face-down rendering, and context menus.
  - Adds individual card selection with:
      - Green selection borders
      - Numbered selection order
      - Click-again deselection and automatic renumbering

  - Adds a LibraryAddCheckTwoTone control that selects a card and every card beneath it.
  - Disables card and stack dragging inside the dialog.
  - Adds a Trash button that:
      - Activates after at least one card is selected
      - Moves selected cards to the player’s trash
      - Synchronizes moves through the WebSocket
      - Sends a field update to chat
      - Plays the trash sound

  - Keeps opponent stacks view-only.
  - Resets selections when the dialog closes or changes stacks.
  - Supports closing with the Close button, backdrop click, or Escape key.
<img width="1032" height="546" alt="Screenshot 2026-07-17 at 2 50 37 PM" src="https://github.com/user-attachments/assets/8bd344dd-8d14-4758-a896-d56141df8be7" />
<img width="1048" height="561" alt="Screenshot 2026-07-17 at 2 50 43 PM" src="https://github.com/user-attachments/assets/6ea3d00f-51e3-4681-9c3a-c6dde514d2b3" />

