### PR TITLE
Added Immunity Marker

### DIFF
--- a/frontend/src/components/Card.test.tsx
+++ b/frontend/src/components/Card.test.tsx
@@ -45,6 +45,7 @@ describe("Card keyword animations", () => {
         renderCard(makeCard([]));
         expect(screen.queryByAltText("suspended")).not.toBeInTheDocument();
         expect(screen.queryByTestId("taunt-pulse-overlay")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("immune-icon-overlay")).not.toBeInTheDocument();
     });
 
     it("renders the SICK animation when SICK is toggled on", () => {
@@ -57,6 +58,14 @@ describe("Card keyword animations", () => {
         renderCard(makeCard(["TAUNT"]));
         expect(screen.getByTestId("taunt-pulse-overlay")).toBeInTheDocument();
         expect(screen.queryByAltText("suspended")).not.toBeInTheDocument();
+    });
+
+    it("renders the pulsing moderator icon when IMMUNE is toggled on", () => {
+        renderCard(makeCard(["IMMUNE"]));
+
+        expect(screen.getByTestId("immune-icon-overlay")).toBeInTheDocument();
+        expect(screen.queryByAltText("suspended")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("taunt-pulse-overlay")).not.toBeInTheDocument();
     });
 
     it("clears the SICK animation when the keyword is removed", () => {
@@ -87,6 +96,21 @@ describe("Card keyword animations", () => {
         });
 
         expect(screen.queryByTestId("taunt-pulse-overlay")).not.toBeInTheDocument();
+    });
+
+    it("clears the IMMUNE icon when the keyword is removed", () => {
+        const card = makeCard(["IMMUNE"]);
+        renderCard(card);
+        expect(screen.getByTestId("immune-icon-overlay")).toBeInTheDocument();
+
+        act(() => {
+            useGameBoardStates.getState().setModifiers(card.id, LOCATION, {
+                ...card.modifiers,
+                keywords: [],
+            });
+        });
+
+        expect(screen.queryByTestId("immune-icon-overlay")).not.toBeInTheDocument();
     });
 
     it("switches from the SICK animation to the TAUNT animation when keywords change", () => {

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -9,6 +9,7 @@ import activateEffectAnimation from "../assets/lotties/activate-effect-animation
 import targetAnimation from "../assets/lotties/target-animation.json";
 import suspendedAPNG from "../assets/lotties/square-sparkle-apng.png";
 import { ContentCopyTwoTone as DragStackIcon, Shield as ShieldIcon } from "@mui/icons-material";
+import AddModeratorIcon from "@mui/icons-material/AddModerator";
 import cardBackSrc from "../assets/cardBack.jpg";
 import { useSound } from "../hooks/useSound.ts";
 import { getSleeve } from "../utils/sleeves.ts";
@@ -508,7 +509,7 @@ export default function Card(props: CardProps) {
                                     )}
                                     <KeywordWrapper>
                                         {modifiers?.keywords
-                                            .filter((w) => w !== "SICK" && w !== "TAUNT")
+                                            .filter((w) => w !== "SICK" && w !== "TAUNT" && w !== "IMMUNE")
                                             .map((keyword) => (
                                                 <ModifierSpan keyword={keyword} key={`${keyword}_${card.id}`}>
                                                     <span>{keyword}</span>
@@ -564,6 +565,11 @@ export default function Card(props: CardProps) {
                     <CardAnimationContainer style={{ top: 0, left: 0, right: 0, bottom: 0 }}>
                         <TauntPulseOverlay data-testid="taunt-pulse-overlay" />
                     </CardAnimationContainer>
+                )}
+                {card.modifiers.keywords.includes("IMMUNE") && (
+                    <ImmuneIconOverlay data-testid="immune-icon-overlay" title="Unaffected by effects">
+                        <AddModeratorIcon fontSize="small" />
+                    </ImmuneIconOverlay>
                 )}
 
                 <StyledImage
@@ -723,6 +729,39 @@ const TauntPulseOverlay = styled.div`
             box-shadow:
                 0 0 18px 6px rgba(255, 0, 0, 0.95),
                 inset 0 0 14px 4px rgba(255, 0, 0, 0.75);
+        }
+    }
+`;
+
+const ImmuneIconOverlay = styled.div`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 16000;
+    display: grid;
+    width: 28px;
+    height: 28px;
+    place-items: center;
+    border: 1px solid rgba(190, 235, 255, 0.9);
+    border-radius: 50%;
+    background: rgba(8, 31, 48, 0.88);
+    color: #9fe4ff;
+    pointer-events: none;
+    animation: immune-pulse 1.25s ease-in-out infinite;
+
+    @keyframes immune-pulse {
+        0%,
+        100% {
+            transform: translate(-50%, -50%) scale(0.92);
+            box-shadow: 0 0 4px 1px rgba(71, 190, 255, 0.45);
+            filter: brightness(0.9);
+        }
+        50% {
+            transform: translate(-50%, -50%) scale(1.08);
+            box-shadow:
+                0 0 10px 3px rgba(71, 190, 255, 0.95),
+                0 0 18px 5px rgba(71, 190, 255, 0.35);
+            filter: brightness(1.25);
         }
     }
 `;

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.test.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.test.tsx
@@ -54,7 +54,7 @@ function renderMenu(card: CardTypeGame) {
     return { sendSetModifiers };
 }
 
-describe("ModifierMenu SICK / TAUNT toggles", () => {
+describe("ModifierMenu status toggles", () => {
     beforeEach(() => {
         useGameBoardStates.setState({ [LOCATION]: [], cardToSend: null } as never);
     });
@@ -139,6 +139,47 @@ describe("ModifierMenu SICK / TAUNT toggles", () => {
 
         await user.click(tauntCheckbox);
         expect(tauntCheckbox.checked).toBe(false);
+
+        await user.click(screen.getByText("SAVE VALUES"));
+        expect(sendSetModifiers).toHaveBeenCalledWith(
+            card.id,
+            LOCATION,
+            expect.objectContaining({ keywords: [] })
+        );
+    });
+
+    it("toggles IMMUNE without affecting the other status modifiers", async () => {
+        const user = userEvent.setup();
+        const card = makeCard([]);
+        const { sendSetModifiers } = renderMenu(card);
+
+        const immuneCheckbox = screen.getByLabelText("(Un)Mark as unaffected by effects") as HTMLInputElement;
+        const sickCheckbox = screen.getByLabelText("(Un)Mark as sick / stunned 💫") as HTMLInputElement;
+        const tauntCheckbox = screen.getByLabelText("(Un)Mark as taunted💢") as HTMLInputElement;
+
+        await user.click(immuneCheckbox);
+        expect(immuneCheckbox.checked).toBe(true);
+        expect(sickCheckbox.checked).toBe(false);
+        expect(tauntCheckbox.checked).toBe(false);
+
+        await user.click(screen.getByText("SAVE VALUES"));
+        expect(sendSetModifiers).toHaveBeenCalledWith(
+            card.id,
+            LOCATION,
+            expect.objectContaining({ keywords: ["IMMUNE"] })
+        );
+    });
+
+    it("unchecking IMMUNE removes it from the saved keywords", async () => {
+        const user = userEvent.setup();
+        const card = makeCard(["IMMUNE"]);
+        const { sendSetModifiers } = renderMenu(card);
+
+        const immuneCheckbox = screen.getByLabelText("(Un)Mark as unaffected by effects") as HTMLInputElement;
+        expect(immuneCheckbox.checked).toBe(true);
+
+        await user.click(immuneCheckbox);
+        expect(immuneCheckbox.checked).toBe(false);
 
         await user.click(screen.getByText("SAVE VALUES"));
         expect(sendSetModifiers).toHaveBeenCalledWith(

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
@@ -222,7 +222,7 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
                                 className="button"
                                 style={{ display: "flex", alignItems: "center", gap: 4 }}
                             >
-                                (Un)Mark as unaffected by effects
+                                (Un)Mark as immune
                                 <AddModeratorIcon fontSize="small" />
                             </label>
                         </div>

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 import Lottie from "lottie-react";
 import { useEffect, useState } from "react";
 import { AddCircleOutlined, RemoveCircleOutlined } from "@mui/icons-material";
+import AddModeratorIcon from "@mui/icons-material/AddModerator";
 import { useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
 import { CardModifiers, CardTypeGame } from "../../../utils/types.ts";
 import { getNumericModifier, numbersWithModifiers } from "../../../utils/functions.ts";
@@ -104,6 +105,11 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
         else setKeywords([...keywords, "TAUNT"]);
     }
 
+    function handleSetImmune() {
+        if (keywords.includes("IMMUNE")) setKeywords((prev) => prev.filter((kw) => kw !== "IMMUNE"));
+        else setKeywords([...keywords, "IMMUNE"]);
+    }
+
     // eslint-disable-next-line
     useEffect(() => resetValues(), [cardToSend]);
 
@@ -161,7 +167,7 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
 
                         <Stack direction={"row"} gap={0.5} maxWidth={"100%"} flexWrap={"wrap"}>
                             {keywords
-                                .filter((w) => w !== "SICK" && w !== "TAUNT")
+                                .filter((w) => w !== "SICK" && w !== "TAUNT" && w !== "IMMUNE")
                                 .map((keyword) => (
                                     <ModifierSpan
                                         onClick={() => setKeywords((prev) => prev.filter((kw) => kw !== keyword))}
@@ -199,6 +205,25 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
                             />
                             <label htmlFor="toggleTaunt" className="button">
                                 (Un)Mark as taunted💢
+                            </label>
+                        </div>
+                        <div style={{ width: "100%", display: "flex", alignItems: "center" }}>
+                            <input
+                                type="checkbox"
+                                name="stackDrag"
+                                value="Toggle"
+                                id="toggleImmune"
+                                className="button"
+                                checked={keywords.includes("IMMUNE")}
+                                onChange={handleSetImmune}
+                            />
+                            <label
+                                htmlFor="toggleImmune"
+                                className="button"
+                                style={{ display: "flex", alignItems: "center", gap: 4 }}
+                            >
+                                (Un)Mark as unaffected by effects
+                                <AddModeratorIcon fontSize="small" />
                             </label>
                         </div>
 


### PR DESCRIPTION
## PR Summary

  Adds an immunity modifier for cards.

  ### Changes

  - Added an IMMUNE checkbox to the modifier menu.
  - Added functionality to apply and remove the IMMUNE keyword.
  - Added MUI’s small AddModeratorIcon beside the menu label.
  - Displays the moderator icon in the center of immune cards.
  - Added a blue pulsing glow animation to the card icon.
  - Prevented the immunity overlay from interfering with card clicks and dragging.
  - Excluded IMMUNE from the standard keyword tag list.
  - Added tests covering:
      - Applying immunity.
      - Removing immunity.
      - Rendering the immunity icon.
      - Removing the icon when immunity is cleared.
      - Keeping immunity independent from SICK and TAUNT.

<img width="366" height="418" alt="Screenshot 2026-07-19 at 1 08 34 PM" src="https://github.com/user-attachments/assets/575f96ab-9002-4f69-815e-88417cd27c17" />
<img width="621" height="346" alt="Screenshot 2026-07-19 at 12 48 28 PM" src="https://github.com/user-attachments/assets/5b763f73-6503-4c1e-a3a9-a7faa7f904a8" />



