### PR TITLE
Added Functionality to Support Modifying Dual cards

### DIFF
--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mui/icons-material";
 import { CSSProperties } from "react";
 import ModifierMenu from "./ModifierMenu.tsx";
-import { convertForLog, numbersWithModifiers } from "../../../utils/functions.ts";
+import { cardTypesWithModifiers, convertForLog, numbersWithModifiers } from "../../../utils/functions.ts";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
 import { tamerLocations, useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
 import { useSound } from "../../../hooks/useSound.ts";
@@ -67,7 +67,8 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
     const playModifyCardSfx = useSound((state) => state.playModifyCardSfx);
 
     const hasModifierMenu =
-        contextCard?.cardType === "Digimon" || numbersWithModifiers.includes(String(contextCard?.cardNumber));
+        cardTypesWithModifiers.includes(String(contextCard?.cardType)) ||
+        numbersWithModifiers.includes(String(contextCard?.cardNumber));
     const isTamer = contextCard?.cardType.includes("Tamer") ?? false;
     const isStunned = contextCard?.modifiers.keywords.includes("SICK") ?? false;
     const hideMenuItemStyle = hasModifierMenu ? {} : { visibility: "hidden", position: "absolute" };

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.test.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.test.tsx
@@ -25,13 +25,13 @@ vi.mock("react-contexify", () => ({
 
 const LOCATION = "myDigi1";
 
-function makeCard(keywords: string[]): CardTypeGame {
+function makeCard(keywords: string[], cardType = "Digimon"): CardTypeGame {
     return {
         id: "test-card-1",
         uniqueCardNumber: "BT1-001",
         name: "Test Digimon",
         imgUrl: "https://example.com/card.jpg",
-        cardType: "Digimon",
+        cardType,
         color: ["Red"],
         cardNumber: "BT1-001",
         restrictions: { chinese: "", english: "", japanese: "", korean: "" },
@@ -57,6 +57,22 @@ function renderMenu(card: CardTypeGame) {
 describe("ModifierMenu SICK / TAUNT toggles", () => {
     beforeEach(() => {
         useGameBoardStates.setState({ [LOCATION]: [], cardToSend: null } as never);
+    });
+
+    it("supports setting modifiers on Digimon/Option cards", async () => {
+        const user = userEvent.setup();
+        const card = makeCard([], "Digimon/Option");
+        const { sendSetModifiers } = renderMenu(card);
+
+        expect(screen.getByText("Set Modifiers")).toBeInTheDocument();
+        await user.click(screen.getByLabelText("(Un)Mark as taunted💢"));
+        await user.click(screen.getByText("SAVE VALUES"));
+
+        expect(sendSetModifiers).toHaveBeenCalledWith(
+            card.id,
+            LOCATION,
+            expect.objectContaining({ keywords: ["TAUNT"] })
+        );
     });
 
     it("toggles the SICK checkbox on and includes SICK in the saved keywords", async () => {
@@ -122,11 +138,7 @@ describe("ModifierMenu SICK / TAUNT toggles", () => {
         expect(sickCheckbox.checked).toBe(false);
 
         await user.click(screen.getByText("SAVE VALUES"));
-        expect(sendSetModifiers).toHaveBeenCalledWith(
-            card.id,
-            LOCATION,
-            expect.objectContaining({ keywords: [] })
-        );
+        expect(sendSetModifiers).toHaveBeenCalledWith(card.id, LOCATION, expect.objectContaining({ keywords: [] }));
     });
 
     it("unchecking TAUNT removes it from the saved keywords, clearing the animation trigger", async () => {
@@ -141,10 +153,6 @@ describe("ModifierMenu SICK / TAUNT toggles", () => {
         expect(tauntCheckbox.checked).toBe(false);
 
         await user.click(screen.getByText("SAVE VALUES"));
-        expect(sendSetModifiers).toHaveBeenCalledWith(
-            card.id,
-            LOCATION,
-            expect.objectContaining({ keywords: [] })
-        );
+        expect(sendSetModifiers).toHaveBeenCalledWith(card.id, LOCATION, expect.objectContaining({ keywords: [] }));
     });
 });

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { AddCircleOutlined, RemoveCircleOutlined } from "@mui/icons-material";
 import { useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
 import { CardModifiers, CardTypeGame } from "../../../utils/types.ts";
-import { getNumericModifier, numbersWithModifiers } from "../../../utils/functions.ts";
+import { cardTypesWithModifiers, getNumericModifier, numbersWithModifiers } from "../../../utils/functions.ts";
 import { useSound } from "../../../hooks/useSound.ts";
 
 type ModifierMenuProps = {
@@ -117,7 +117,11 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
             card?.modifiers.keywords !== keywords ||
             card?.modifiers.colors !== colors);
 
-    if (card?.cardType !== "Digimon" && !numbersWithModifiers.includes(String(card?.cardNumber))) return <></>;
+    if (
+        !cardTypesWithModifiers.includes(String(card?.cardType)) &&
+        !numbersWithModifiers.includes(String(card?.cardNumber))
+    )
+        return <></>;
 
     return (
         <StyledSubmenu label={"Set Modifiers"} arrow={<StyledLottie animationData={arrowsAnimation} />}>

--- a/frontend/src/utils/functions.ts
+++ b/frontend/src/utils/functions.ts
@@ -124,3 +124,4 @@ export function getNumericModifier(value: number, isSetting?: boolean) {
 }
 
 export const numbersWithModifiers = ["BT12-092", "BT17-087", "BT13-095", "BT13-099", "EX2-007", "BT21-086"];
+export const cardTypesWithModifiers = ["Digimon", "Digimon/Option"];


### PR DESCRIPTION
 ## PR Summary

  Adds modifier support for dual-type Digimon/Option cards.

  ### Changes

  - Enabled the Set Modifiers menu for Digimon/Option cards.
  - Enabled the Clear Modifiers action for Digimon/Option cards.
  - Centralized supported card types using cardTypesWithModifiers.
  - Preserved existing modifier support for Digimon cards and special card numbers.
  - Added test coverage for setting modifiers on Digimon/Option cards.

  ### Verification

  - Frontend production build passes.
  - Formatting and diff validation pass.

<img width="378" height="221" alt="Screenshot 2026-07-19 at 1 24 26 PM" src="https://github.com/user-attachments/assets/350ac14f-f604-4c63-9173-50ac0d7c2a6f" />
<img width="602" height="479" alt="Screenshot 2026-07-19 at 1 24 33 PM" src="https://github.com/user-attachments/assets/e1d97d4b-d678-4802-8e2a-b075b40e36ea" />
