### PR TITLE
Fixed Player Count Functionality

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/OnlinePlayerCountChangedEvent.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/OnlinePlayerCountChangedEvent.java
@@ -1,0 +1,4 @@
+package com.github.wekaito.backend.websocket;
+
+public record OnlinePlayerCountChangedEvent() {
+}

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.wekaito.backend.models.Card;
 import com.github.wekaito.backend.DeckService;
 import com.github.wekaito.backend.security.MongoUserDetailsService;
+import com.github.wekaito.backend.websocket.OnlinePlayerCountChangedEvent;
 import com.github.wekaito.backend.websocket.game.models.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -30,6 +32,8 @@ public class GameWebSocket extends TextWebSocketHandler {
     private final DeckService deckService;
     
     private final CardJsonConverter cardJsonConverter;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     public final ConcurrentHashMap<String, GameRoom> gameRooms = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> roomIdBySessionId = new ConcurrentHashMap<>();
@@ -72,6 +76,8 @@ public class GameWebSocket extends TextWebSocketHandler {
                 }
             }
         }
+
+        eventPublisher.publishEvent(new OnlinePlayerCountChangedEvent());
     }
 
     @Override
@@ -535,6 +541,7 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         gameRoom.addSession(session);
         roomIdBySessionId.put(session.getId(), gameId);
+        eventPublisher.publishEvent(new OnlinePlayerCountChangedEvent());
 
         GameRoom gameRoomFromMap = gameRooms.get(gameId); // Retrieve again to ensure consistency
 

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -6,11 +6,13 @@ import com.github.wekaito.backend.models.ChatMessage;
 import com.github.wekaito.backend.CardService;
 import com.github.wekaito.backend.DeckService;
 import com.github.wekaito.backend.security.MongoUserDetailsService;
+import com.github.wekaito.backend.websocket.OnlinePlayerCountChangedEvent;
 import com.github.wekaito.backend.websocket.game.GameWebSocket;
 import com.github.wekaito.backend.websocket.game.models.GameRoom;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
@@ -83,6 +85,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         }
 
         globalActiveSessions.removeIf(s -> Objects.equals(Objects.requireNonNull(s.getPrincipal()).getName(), username));
+        globalActiveSessions.add(session);
+        broadcastUserCount();
         if (tryReconnectToRoom(session)) return; // Try to reconnect first
 
         List<String> userBlockedAccounts = mongoUserDetailsService.getBlockedAccounts(username);
@@ -95,9 +99,6 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         sendTextMessage(session, "[ROOMS]:" + objectMapper.writeValueAsString(openRoomsDTO));
         sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
-        sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
-
-        globalActiveSessions.add(session);
     }
 
     @Override
@@ -132,6 +133,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         quickPlayQueue.remove(session);
 
         globalActiveSessions.remove(session);
+        broadcastUserCount();
     }
 
 
@@ -141,6 +143,11 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (payload.equals("/heartbeat/")) {
             lastHeartbeatTimestamps.put(session, System.currentTimeMillis());
+            return;
+        }
+
+        if (payload.equals("/requestUserCount")) {
+            broadcastUserCount();
             return;
         }
 
@@ -290,9 +297,13 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     @Scheduled(fixedRate = 5000) // 5 seconds
     private void shortIntervalOperations() throws IOException {
-        broadcastUserCount();
         checkForRejoinableGameRoom();
         broadcastRooms();
+    }
+
+    @Scheduled(fixedRate = 5000) // fallback in case a WebSocket lifecycle event is missed
+    private void userCountFallback() throws IOException {
+        broadcastUserCount();
     }
 
     @Scheduled(fixedRate = 30000) // 30 seconds
@@ -456,14 +467,26 @@ public class LobbyWebSocket extends TextWebSocketHandler {
                 .map(WebSocketSession::getPrincipal)
                 .filter(Objects::nonNull)
                 .map(Principal::getName)
+                .distinct()
                 .sorted(String.CASE_INSENSITIVE_ORDER)
                 .toList();
         String lobbyPlayersMessage = "[LOBBY_PLAYERS]:" + objectMapper.writeValueAsString(lobbyPlayers);
+        String userCountMessage = "[USER_COUNT]:" + getTotalSessionCount();
+        String quickPlayCountMessage = "[USER_COUNT_QUICK_PLAY]:" + quickPlayQueue.size();
 
         for (WebSocketSession session : globalActiveSessions) {
-            sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
-            sendTextMessage(session, "[USER_COUNT_QUICK_PLAY]:" + quickPlayQueue.size());
+            sendTextMessage(session, userCountMessage);
+            sendTextMessage(session, quickPlayCountMessage);
             sendTextMessage(session, lobbyPlayersMessage);
+        }
+    }
+
+    @EventListener
+    public void handleOnlinePlayerCountChanged(OnlinePlayerCountChangedEvent ignored) {
+        try {
+            broadcastUserCount();
+        } catch (IOException e) {
+            System.err.println("Failed to broadcast online player count: " + e.getMessage());
         }
     }
 
@@ -476,8 +499,23 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     }
 
     private int getTotalSessionCount() {
-        int inGameSessionCount = gameWebSocket.gameRooms.size() * 2;
-        return globalActiveSessions.size() + inGameSessionCount;
+        Set<String> activePlayerNames = new HashSet<>();
+
+        globalActiveSessions.stream()
+                .map(WebSocketSession::getPrincipal)
+                .filter(Objects::nonNull)
+                .map(Principal::getName)
+                .forEach(activePlayerNames::add);
+
+        gameWebSocket.gameRooms.values().stream()
+                .flatMap(gameRoom -> gameRoom.getSessions().stream())
+                .filter(WebSocketSession::isOpen)
+                .map(WebSocketSession::getPrincipal)
+                .filter(Objects::nonNull)
+                .map(Principal::getName)
+                .forEach(activePlayerNames::add);
+
+        return activePlayerNames.size();
     }
 
     private RoomDTO getRoomDTO(Room room) {

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
@@ -1,0 +1,118 @@
+package com.github.wekaito.backend.websocket;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestWebSocketSession implements WebSocketSession {
+    private final String id;
+    private final Principal principal;
+    private final List<String> messages = new ArrayList<>();
+    private boolean open = true;
+    private int textMessageSizeLimit;
+    private int binaryMessageSizeLimit;
+
+    public TestWebSocketSession(String id, String username) {
+        this.id = id;
+        this.principal = () -> username;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public URI getUri() {
+        return URI.create("ws://localhost/test");
+    }
+
+    @Override
+    public HttpHeaders getHandshakeHeaders() {
+        return HttpHeaders.EMPTY;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public String getAcceptedProtocol() {
+        return null;
+    }
+
+    @Override
+    public void setTextMessageSizeLimit(int messageSizeLimit) {
+        textMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getTextMessageSizeLimit() {
+        return textMessageSizeLimit;
+    }
+
+    @Override
+    public void setBinaryMessageSizeLimit(int messageSizeLimit) {
+        binaryMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getBinaryMessageSizeLimit() {
+        return binaryMessageSizeLimit;
+    }
+
+    @Override
+    public List<WebSocketExtension> getExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public void sendMessage(WebSocketMessage<?> message) {
+        messages.add(message.getPayload().toString());
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+
+    @Override
+    public void close(CloseStatus status) {
+        open = false;
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketOnlineCountEventTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketOnlineCountEventTest.java
@@ -1,0 +1,67 @@
+package com.github.wekaito.backend.websocket.game;
+
+import com.github.wekaito.backend.websocket.OnlinePlayerCountChangedEvent;
+import com.github.wekaito.backend.websocket.TestWebSocketSession;
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameWebSocketOnlineCountEventTest {
+
+    @Test
+    void joiningGamePublishesPlayerCountChange() throws Exception {
+        RecordingEventPublisher eventPublisher = new RecordingEventPublisher();
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, eventPublisher);
+        GameRoom gameRoom = new GameRoom(
+                "Aaron‗Beatrice",
+                new Player("Aaron", "", "", ""),
+                List.of(),
+                List.of(),
+                new Player("Beatrice", "", "", ""),
+                List.of(),
+                List.of()
+        );
+        gameWebSocket.getGameRooms().put(gameRoom.getRoomId(), gameRoom);
+
+        gameWebSocket.handleTextMessage(
+                new TestWebSocketSession("game-1", "Aaron"),
+                new TextMessage("/joinGame:" + gameRoom.getRoomId())
+        );
+
+        assertThat(eventPublisher.events)
+                .singleElement()
+                .isInstanceOf(OnlinePlayerCountChangedEvent.class);
+    }
+
+    @Test
+    void closingGameConnectionPublishesPlayerCountChange() {
+        RecordingEventPublisher eventPublisher = new RecordingEventPublisher();
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, eventPublisher);
+
+        gameWebSocket.afterConnectionClosed(
+                new TestWebSocketSession("game-1", "Aaron"),
+                CloseStatus.NORMAL
+        );
+
+        assertThat(eventPublisher.events)
+                .singleElement()
+                .isInstanceOf(OnlinePlayerCountChangedEvent.class);
+    }
+
+    private static class RecordingEventPublisher implements ApplicationEventPublisher {
+        private final List<Object> events = new ArrayList<>();
+
+        @Override
+        public void publishEvent(Object event) {
+            events.add(event);
+        }
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocketTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocketTest.java
@@ -1,0 +1,117 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+import com.github.wekaito.backend.DeckService;
+import com.github.wekaito.backend.StarterDeckService;
+import com.github.wekaito.backend.models.Card;
+import com.github.wekaito.backend.models.Deck;
+import com.github.wekaito.backend.security.MongoUserDetailsService;
+import com.github.wekaito.backend.websocket.TestWebSocketSession;
+import com.github.wekaito.backend.websocket.game.GameWebSocket;
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LobbyWebSocketTest {
+    private LobbyWebSocket lobbyWebSocket;
+    private GameWebSocket gameWebSocket;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lobbyWebSocket = new LobbyWebSocket(new TestUserDetailsService(), new TestDeckService(), null);
+        gameWebSocket = new GameWebSocket(null, null, null, event -> { });
+
+        Field gameWebSocketField = LobbyWebSocket.class.getDeclaredField("gameWebSocket");
+        gameWebSocketField.setAccessible(true);
+        gameWebSocketField.set(lobbyWebSocket, gameWebSocket);
+    }
+
+    @Test
+    void enteringLobbyImmediatelyBroadcastsTheUpdatedCount() throws Exception {
+        TestWebSocketSession session = new TestWebSocketSession("lobby-1", "Aaron");
+
+        lobbyWebSocket.afterConnectionEstablished(session);
+
+        assertThat(session.getMessages())
+                .contains("[USER_COUNT]:1", "[LOBBY_PLAYERS]:[\"Aaron\"]");
+    }
+
+    @Test
+    void countRequestBroadcastsDistinctLobbyAndGamePlayers() throws Exception {
+        TestWebSocketSession lobbySession = new TestWebSocketSession("lobby-1", "Aaron");
+        lobbyWebSocket.getGlobalActiveSessions().add(lobbySession);
+
+        GameRoom gameRoom = gameRoom("Aaron", "Beatrice");
+        gameRoom.addSession(new TestWebSocketSession("game-1", "Aaron"));
+        gameRoom.addSession(new TestWebSocketSession("game-2", "Beatrice"));
+        gameWebSocket.getGameRooms().put(gameRoom.getRoomId(), gameRoom);
+
+        lobbyWebSocket.handleTextMessage(lobbySession, new TextMessage("/requestUserCount"));
+
+        assertThat(lobbySession.getMessages()).contains("[USER_COUNT]:2");
+    }
+
+    @Test
+    void leavingLobbyImmediatelyBroadcastsTheUpdatedCount() throws Exception {
+        TestWebSocketSession leavingSession = new TestWebSocketSession("lobby-1", "Aaron");
+        TestWebSocketSession remainingSession = new TestWebSocketSession("lobby-2", "Beatrice");
+        lobbyWebSocket.getGlobalActiveSessions().add(leavingSession);
+        lobbyWebSocket.getGlobalActiveSessions().add(remainingSession);
+
+        lobbyWebSocket.afterConnectionClosed(leavingSession, CloseStatus.NORMAL);
+
+        assertThat(remainingSession.getMessages())
+                .contains("[USER_COUNT]:1", "[LOBBY_PLAYERS]:[\"Beatrice\"]");
+    }
+
+    private GameRoom gameRoom(String playerOne, String playerTwo) {
+        return new GameRoom(
+                playerOne + "‗" + playerTwo,
+                new Player(playerOne, "", "", ""),
+                List.of(),
+                List.of(),
+                new Player(playerTwo, "", "", ""),
+                List.of(),
+                List.of()
+        );
+    }
+
+    private static class TestUserDetailsService extends MongoUserDetailsService {
+        TestUserDetailsService() {
+            super(null, (StarterDeckService) null);
+        }
+
+        @Override
+        public String getActiveDeck(String username) {
+            return "deck-id";
+        }
+
+        @Override
+        public List<String> getBlockedAccounts(String username) {
+            return List.of();
+        }
+    }
+
+    private static class TestDeckService extends DeckService {
+        TestDeckService() {
+            super(null, null, null);
+        }
+
+        @Override
+        public Deck getDeckById(String id) {
+            return new Deck(id, "Test", List.of(), List.of(), "", "", "", "Aaron");
+        }
+
+        @Override
+        public List<Card> getMainDeckCardsById(String id) {
+            return List.of();
+        }
+    }
+}


### PR DESCRIPTION
 ### Overview
Fixes the lobby’s online player count so it accurately and immediately reflects distinct players currently connected to the lobby or an active game.

  ### Changes

  - Count distinct usernames instead of assuming every game room contains two online players.
  - Prevent players transitioning between the lobby and a game from being double-counted.
  - Broadcast count updates immediately when players:
      - Enter or leave the lobby.
      - Join or disconnect from a game.

  - Add a frontend WebSocket-ready request for the latest count.
  - Calculate the count once per broadcast and reuse it for all recipients.
  - Keep the existing 5-second broadcast as a fallback synchronization mechanism.
  - Separate count synchronization from heavier room and reconnect updates.
  - Filter duplicate usernames from the lobby player list.

  ### Tests

  Added coverage for:

  - Immediate count updates when entering the lobby.
  - Immediate lobby player-list updates.
  - Distinct counting across lobby and game connections.
  - Immediate updates when leaving the lobby.
  - Game join and disconnect count-change events.

  All five tests pass with zero failures or errors.