### PR TITLE
Added Player Status Functionality

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -40,6 +40,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     private final CardService cardService;
 
     private final Set<WebSocketSession> globalActiveSessions = ConcurrentHashMap.newKeySet();
+    private final Map<WebSocketSession, PlayerStatus> playerStatuses = new ConcurrentHashMap<>();
     private final Set<Room> rooms = ConcurrentHashMap.newKeySet();
     private final Set<PendingGameInvite> pendingGameInvites = ConcurrentHashMap.newKeySet();
 
@@ -68,6 +69,13 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         lastHeartbeatTimestamps.put(session, System.currentTimeMillis());
 
         String username = principal.getName();
+        PlayerStatus initialStatus = getRequestedPlayerStatus(session);
+
+        if (initialStatus != PlayerStatus.LOBBY) {
+            registerActiveSession(session, username, initialStatus);
+            broadcastUserCount();
+            return;
+        }
 
         String activeDeck = mongoUserDetailsService.getActiveDeck(username);
         if (activeDeck.isEmpty() || deckService.getDeckById(activeDeck) == null) {
@@ -82,7 +90,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             return;
         }
 
-        globalActiveSessions.removeIf(s -> Objects.equals(Objects.requireNonNull(s.getPrincipal()).getName(), username));
+        registerActiveSession(session, username, PlayerStatus.LOBBY);
+        broadcastUserCount();
         if (tryReconnectToRoom(session)) return; // Try to reconnect first
 
         List<String> userBlockedAccounts = mongoUserDetailsService.getBlockedAccounts(username);
@@ -97,7 +106,6 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
         sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
 
-        globalActiveSessions.add(session);
     }
 
     @Override
@@ -132,6 +140,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         quickPlayQueue.remove(session);
 
         globalActiveSessions.remove(session);
+        playerStatuses.remove(session);
+        broadcastUserCount();
     }
 
 
@@ -141,6 +151,11 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (payload.equals("/heartbeat/")) {
             lastHeartbeatTimestamps.put(session, System.currentTimeMillis());
+            return;
+        }
+
+        if (payload.startsWith("/setPlayerStatus:")) {
+            setPlayerStatus(session, payload.substring("/setPlayerStatus:".length()));
             return;
         }
 
@@ -452,18 +467,89 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     }
 
     private void broadcastUserCount() throws IOException {
-        List<String> lobbyPlayers = globalActiveSessions.stream()
-                .map(WebSocketSession::getPrincipal)
-                .filter(Objects::nonNull)
-                .map(Principal::getName)
-                .sorted(String.CASE_INSENSITIVE_ORDER)
+        Map<String, PlayerStatus> onlinePlayerStatuses = new HashMap<>();
+
+        globalActiveSessions.stream()
+                .filter(session -> session.getPrincipal() != null)
+                .forEach(session -> onlinePlayerStatuses.put(
+                        Objects.requireNonNull(session.getPrincipal()).getName(),
+                        playerStatuses.getOrDefault(session, PlayerStatus.LOBBY)
+                ));
+
+        rooms.stream()
+                .filter(room -> room.getPlayers().size() >= 2)
+                .flatMap(room -> room.getPlayers().stream())
+                .forEach(player -> onlinePlayerStatuses.put(player.getName(), PlayerStatus.GAME_ROOM));
+
+        gameWebSocket.gameRooms.values().forEach(gameRoom -> {
+            onlinePlayerStatuses.put(gameRoom.getPlayer1().username(), PlayerStatus.MATCH);
+            onlinePlayerStatuses.put(gameRoom.getPlayer2().username(), PlayerStatus.MATCH);
+        });
+
+        List<OnlinePlayerDTO> onlinePlayers = onlinePlayerStatuses.entrySet().stream()
+                .map(entry -> new OnlinePlayerDTO(entry.getKey(), entry.getValue().displayText))
+                .sorted(Comparator.comparing(OnlinePlayerDTO::name, String.CASE_INSENSITIVE_ORDER))
                 .toList();
-        String lobbyPlayersMessage = "[LOBBY_PLAYERS]:" + objectMapper.writeValueAsString(lobbyPlayers);
+        String lobbyPlayersMessage = "[LOBBY_PLAYERS]:" + objectMapper.writeValueAsString(onlinePlayers);
 
         for (WebSocketSession session : globalActiveSessions) {
             sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
             sendTextMessage(session, "[USER_COUNT_QUICK_PLAY]:" + quickPlayQueue.size());
             sendTextMessage(session, lobbyPlayersMessage);
+        }
+    }
+
+    private void setPlayerStatus(WebSocketSession session, String requestedStatus) throws IOException {
+        try {
+            PlayerStatus status = PlayerStatus.valueOf(requestedStatus);
+            if (status == PlayerStatus.MATCH || status == PlayerStatus.GAME_ROOM) return;
+            playerStatuses.put(session, status);
+            broadcastUserCount();
+        } catch (IllegalArgumentException ignored) {
+            // Ignore unknown client-provided statuses.
+        }
+    }
+
+    private void registerActiveSession(WebSocketSession session, String username, PlayerStatus status) {
+        globalActiveSessions.removeIf(existingSession -> {
+            boolean belongsToUser = existingSession.getPrincipal() != null &&
+                    Objects.equals(existingSession.getPrincipal().getName(), username);
+            if (belongsToUser) playerStatuses.remove(existingSession);
+            return belongsToUser;
+        });
+        playerStatuses.put(session, status);
+        globalActiveSessions.add(session);
+    }
+
+    private PlayerStatus getRequestedPlayerStatus(WebSocketSession session) {
+        if (session.getUri() == null || session.getUri().getQuery() == null) return PlayerStatus.LOBBY;
+
+        return Arrays.stream(session.getUri().getQuery().split("&"))
+                .filter(parameter -> parameter.startsWith("status="))
+                .map(parameter -> parameter.substring("status=".length()))
+                .map(status -> {
+                    try {
+                        PlayerStatus parsedStatus = PlayerStatus.valueOf(status);
+                        return parsedStatus == PlayerStatus.MATCH ? PlayerStatus.LOBBY : parsedStatus;
+                    } catch (IllegalArgumentException ignored) {
+                        return PlayerStatus.LOBBY;
+                    }
+                })
+                .findFirst()
+                .orElse(PlayerStatus.LOBBY);
+    }
+
+    private enum PlayerStatus {
+        LOBBY("In lobby"),
+        GAME_ROOM("In Game Room"),
+        MATCH("In a match"),
+        DECKBUILDING("Deck building"),
+        TESTING("Testing");
+
+        private final String displayText;
+
+        PlayerStatus(String displayText) {
+            this.displayText = displayText;
         }
     }
 
@@ -545,7 +631,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             sendRoomUpdate(room, true);
         }
 
-            broadcastRooms();
+        broadcastRooms();
+        broadcastUserCount();
     }
 
     private void handleJoinRoomAttempt(WebSocketSession session, String roomId) throws IOException {
@@ -632,6 +719,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
         sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: You have left the room " + room.getName() + ".");
         broadcastRooms();
+        broadcastUserCount();
     }
 
     private void toggleReady(WebSocketSession session, String roomId) throws IOException {
@@ -689,6 +777,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: You have kicked " + userName + ".");
 
         broadcastRooms();
+        broadcastUserCount();
     }
 
     private void handleChatMessage(WebSocketSession session, String payload) throws IOException {

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/OnlinePlayerDTO.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/OnlinePlayerDTO.java
@@ -1,0 +1,4 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+public record OnlinePlayerDTO(String name, String status) {
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
@@ -1,0 +1,124 @@
+package com.github.wekaito.backend.websocket;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestWebSocketSession implements WebSocketSession {
+    private final String id;
+    private final Principal principal;
+    private final URI uri;
+    private final List<String> messages = new ArrayList<>();
+    private boolean open = true;
+    private int textMessageSizeLimit;
+    private int binaryMessageSizeLimit;
+
+    public TestWebSocketSession(String id, String username) {
+        this(id, username, URI.create("ws://localhost/api/ws/lobby"));
+    }
+
+    public TestWebSocketSession(String id, String username, URI uri) {
+        this.id = id;
+        this.principal = () -> username;
+        this.uri = uri;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public HttpHeaders getHandshakeHeaders() {
+        return HttpHeaders.EMPTY;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public String getAcceptedProtocol() {
+        return null;
+    }
+
+    @Override
+    public void setTextMessageSizeLimit(int messageSizeLimit) {
+        textMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getTextMessageSizeLimit() {
+        return textMessageSizeLimit;
+    }
+
+    @Override
+    public void setBinaryMessageSizeLimit(int messageSizeLimit) {
+        binaryMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getBinaryMessageSizeLimit() {
+        return binaryMessageSizeLimit;
+    }
+
+    @Override
+    public List<WebSocketExtension> getExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public void sendMessage(WebSocketMessage<?> message) {
+        messages.add(message.getPayload().toString());
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+
+    @Override
+    public void close(CloseStatus status) {
+        open = false;
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyPlayerStatusTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyPlayerStatusTest.java
@@ -1,0 +1,159 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+import com.github.wekaito.backend.websocket.TestWebSocketSession;
+import com.github.wekaito.backend.websocket.game.GameWebSocket;
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LobbyPlayerStatusTest {
+    private LobbyWebSocket lobbyWebSocket;
+    private GameWebSocket gameWebSocket;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lobbyWebSocket = new LobbyWebSocket(null, null, null);
+        gameWebSocket = new GameWebSocket(null, null, null);
+
+        Field gameWebSocketField = LobbyWebSocket.class.getDeclaredField("gameWebSocket");
+        gameWebSocketField.setAccessible(true);
+        gameWebSocketField.set(lobbyWebSocket, gameWebSocket);
+    }
+
+    @Test
+    void deckPageConnectionReportsDeckBuildingStatus() throws Exception {
+        TestWebSocketSession session = presenceSession("Aaron", "DECKBUILDING");
+
+        lobbyWebSocket.afterConnectionEstablished(session);
+
+        assertThat(playerListMessage(session)).contains(playerJson("Aaron", "Deck building"));
+    }
+
+    @Test
+    void testPageConnectionReportsTestingStatus() throws Exception {
+        TestWebSocketSession session = presenceSession("Aaron", "TESTING");
+
+        lobbyWebSocket.afterConnectionEstablished(session);
+
+        assertThat(playerListMessage(session)).contains(playerJson("Aaron", "Testing"));
+    }
+
+    @Test
+    void twoPlayersInCreatedRoomBothReportGameRoomStatus() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        TestWebSocketSession guest = lobbySession("Beatrice", "lobby-2");
+        registerLobbySessions(host, guest);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(host, "Aaron", true),
+                        new LobbyPlayer(guest, "Beatrice", false)
+                ))
+        ));
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host))
+                .contains(playerJson("Aaron", "In Game Room"))
+                .contains(playerJson("Beatrice", "In Game Room"));
+    }
+
+    @Test
+    void playerWaitingAloneInCreatedRoomRemainsInLobby() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        registerLobbySessions(host);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(new LobbyPlayer(host, "Aaron", true)))
+        ));
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host)).contains(playerJson("Aaron", "In lobby"));
+    }
+
+    @Test
+    void activeMatchTakesPrecedenceOverGameRoomStatus() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        TestWebSocketSession guest = lobbySession("Beatrice", "lobby-2");
+        registerLobbySessions(host, guest);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(host, "Aaron", true),
+                        new LobbyPlayer(guest, "Beatrice", false)
+                ))
+        ));
+        GameRoom gameRoom = new GameRoom(
+                "Aaron‗Beatrice",
+                new Player("Aaron", "", "", ""),
+                List.of(),
+                List.of(),
+                new Player("Beatrice", "", "", ""),
+                List.of(),
+                List.of()
+        );
+        gameWebSocket.getGameRooms().put(gameRoom.getRoomId(), gameRoom);
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host))
+                .contains(playerJson("Aaron", "In a match"))
+                .contains(playerJson("Beatrice", "In a match"));
+    }
+
+    private TestWebSocketSession presenceSession(String username, String status) {
+        return new TestWebSocketSession(
+                "presence-" + username,
+                username,
+                URI.create("ws://localhost/api/ws/lobby?status=" + status)
+        );
+    }
+
+    private TestWebSocketSession lobbySession(String username, String id) {
+        return new TestWebSocketSession(id, username);
+    }
+
+    private void registerLobbySessions(TestWebSocketSession... sessions) throws Exception {
+        for (TestWebSocketSession session : sessions) {
+            lobbyWebSocket.getGlobalActiveSessions().add(session);
+            lobbyWebSocket.handleTextMessage(session, new TextMessage("/setPlayerStatus:LOBBY"));
+        }
+    }
+
+    private void requestStatusBroadcast(TestWebSocketSession session) throws Exception {
+        lobbyWebSocket.handleTextMessage(session, new TextMessage("/setPlayerStatus:LOBBY"));
+    }
+
+    private String playerListMessage(TestWebSocketSession session) {
+        return session.getMessages().stream()
+                .filter(message -> message.startsWith("[LOBBY_PLAYERS]:"))
+                .reduce((first, second) -> second)
+                .orElseThrow();
+    }
+
+    private String playerJson(String name, String status) {
+        return "{\"name\":\"" + name + "\",\"status\":\"" + status + "\"}";
+    }
+}

--- a/frontend/src/hooks/usePlayerPresence.ts
+++ b/frontend/src/hooks/usePlayerPresence.ts
@@ -1,0 +1,21 @@
+import useWebSocket from "react-use-websocket";
+
+export type PlayerStatus = "LOBBY" | "DECKBUILDING" | "TESTING";
+
+export default function usePlayerPresence(status: PlayerStatus) {
+    const currentPort = window.location.port;
+    const currentUrl = window.location.origin.replace("https://", "");
+    const websocketBaseURL =
+        currentPort === "5173" ? "ws://localhost:8080/api/ws/lobby" : `wss://${currentUrl}/api/ws/lobby`;
+    const websocketURL = `${websocketBaseURL}?status=${status}`;
+
+    useWebSocket(websocketURL, {
+        shouldReconnect: () => true,
+        onOpen: (event) => (event.target as WebSocket).send(`/setPlayerStatus:${status}`),
+        onMessage: (event) => {
+            if (typeof event.data === "string" && event.data.startsWith("[USER_COUNT]:")) {
+                (event.target as WebSocket).send("/heartbeat/");
+            }
+        },
+    });
+}


### PR DESCRIPTION
 ### Overview

  Adds real-time player activity statuses to the lobby’s online-player list.

  ### Player Statuses

  - In lobby
  - In Game Room
  - In a match
  - Deck building
  - Testing

  ### Changes

  - Replace the username-only player payload with structured player status data.
  - Track player presence through the lobby WebSocket.
  - Add a reusable presence hook for the /decks and /test pages.
  - Keep presence connections alive using WebSocket heartbeats.
  - Show In Game Room for both players when a created room has two players.
  - Give active-match status precedence over game-room status.
  - Broadcast updates immediately when players join, leave, or are kicked from a room.
  - Prevent clients from manually claiming server-derived match and game-room statuses.
  - Display status text underneath each username using the requested styling.
  - Preserve username search functionality.

  ### Tests

  Added coverage for:

  - Deck-building status.
  - Testing status.
  - Two-player game-room status.
  - Single-player lobby status.
  - Active-match status precedence.

  All five tests pass with zero failures or errors.

<img width="410" height="358" alt="Screenshot 2026-07-19 at 4 02 35 PM" src="https://github.com/user-attachments/assets/75b69ad9-05a6-409d-9811-75b74179938d" />
