### PR TITLE
Fix Reconnecting Issues

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -241,6 +241,19 @@ public class GameWebSocket extends TextWebSocketHandler {
         return gameRooms.get(gameId);
     }
 
+    /**
+     * Retires any previous match using this ID before the lobby starts a new match.
+     * Game IDs are based on player order, so the same host and opponent can otherwise
+     * reconnect to the previous board instead of loading their currently selected decks.
+     */
+    public void prepareNewGame(String gameId) {
+        GameRoom previousRoom = gameRooms.remove(gameId);
+        if (previousRoom != null) {
+            previousRoom.cancelAllScheduledTasks();
+        }
+        roomIdBySessionId.entrySet().removeIf(entry -> gameId.equals(entry.getValue()));
+    }
+
     public Optional<GameRoom> findGameRoomBySession(WebSocketSession session) {
         String username = Objects.requireNonNull(session.getPrincipal()).getName();
         return gameRooms.values().stream().filter(room ->

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -227,6 +227,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (accepted) {
             String gameId = inviter + "‗" + invitedPlayer;
+            gameWebSocket.prepareNewGame(gameId);
             sendTextMessage(inviterSession, "[COMPUTE_GAME]:" + gameId);
             sendTextMessage(session, "[COMPUTE_GAME]:" + gameId);
             lastPlayerRooms.remove(inviterSession);
@@ -279,6 +280,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         Room room = getRoomById(roomId);
         if (room == null) return;
+
+        gameWebSocket.prepareNewGame(gameId);
 
         for (LobbyPlayer player : room.getPlayers()) {
             sendTextMessage(player.getSession(), "[COMPUTE_GAME]:" + gameId);
@@ -363,6 +366,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             }
 
             String newGameId = username1 + "‗" + username2;
+            gameWebSocket.prepareNewGame(newGameId);
 
             quickPlayQueue.remove(p1);
             quickPlayQueue.remove(p2);

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketTest.java
@@ -1,0 +1,38 @@
+package com.github.wekaito.backend.websocket.game;
+
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GameWebSocketTest {
+
+    @Test
+    void prepareNewGameRetiresPreviousRoomWithSameGameId() {
+        String gameId = "player-one‗player-two";
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        TrackingGameRoom previousRoom = new TrackingGameRoom(gameId);
+        gameWebSocket.gameRooms.put(gameId, previousRoom);
+
+        gameWebSocket.prepareNewGame(gameId);
+
+        assertFalse(gameWebSocket.gameRooms.containsKey(gameId));
+        assertTrue(previousRoom.scheduledTasksCancelled);
+    }
+
+    private static class TrackingGameRoom extends GameRoom {
+        private boolean scheduledTasksCancelled;
+
+        TrackingGameRoom(String gameId) {
+            super(gameId, null, List.of(), List.of(), null, List.of(), List.of());
+        }
+
+        @Override
+        public void cancelAllScheduledTasks() {
+            scheduledTasksCancelled = true;
+        }
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketTest.java
@@ -3,9 +3,13 @@ package com.github.wekaito.backend.websocket.game;
 import com.github.wekaito.backend.websocket.game.models.GameRoom;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GameWebSocketTest {
@@ -21,6 +25,53 @@ class GameWebSocketTest {
 
         assertFalse(gameWebSocket.gameRooms.containsKey(gameId));
         assertTrue(previousRoom.scheduledTasksCancelled);
+    }
+
+    @Test
+    void prepareNewGameClearsOnlySessionMappingsForReplacedGame() throws Exception {
+        String replacedGameId = "player-one‗player-two";
+        String activeGameId = "player-three‗player-four";
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        Map<String, String> roomIdsBySession = getRoomIdsBySession(gameWebSocket);
+        roomIdsBySession.put("old-player-one-session", replacedGameId);
+        roomIdsBySession.put("old-player-two-session", replacedGameId);
+        roomIdsBySession.put("active-player-session", activeGameId);
+
+        gameWebSocket.prepareNewGame(replacedGameId);
+
+        assertFalse(roomIdsBySession.containsKey("old-player-one-session"));
+        assertFalse(roomIdsBySession.containsKey("old-player-two-session"));
+        assertTrue(roomIdsBySession.containsKey("active-player-session"));
+    }
+
+    @Test
+    void prepareNewGameLeavesOtherGameRoomsRunning() {
+        String replacedGameId = "player-one‗player-two";
+        String activeGameId = "player-three‗player-four";
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        TrackingGameRoom replacedRoom = new TrackingGameRoom(replacedGameId);
+        TrackingGameRoom activeRoom = new TrackingGameRoom(activeGameId);
+        gameWebSocket.gameRooms.put(replacedGameId, replacedRoom);
+        gameWebSocket.gameRooms.put(activeGameId, activeRoom);
+
+        gameWebSocket.prepareNewGame(replacedGameId);
+
+        assertSame(activeRoom, gameWebSocket.gameRooms.get(activeGameId));
+        assertFalse(activeRoom.scheduledTasksCancelled);
+    }
+
+    @Test
+    void prepareNewGameIsSafeWhenNoPreviousRoomExists() {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+
+        assertDoesNotThrow(() -> gameWebSocket.prepareNewGame("player-one‗player-two"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> getRoomIdsBySession(GameWebSocket gameWebSocket) throws Exception {
+        Field field = GameWebSocket.class.getDeclaredField("roomIdBySessionId");
+        field.setAccessible(true);
+        return (Map<String, String>) field.get(gameWebSocket);
     }
 
     private static class TrackingGameRoom extends GameRoom {


### PR DESCRIPTION
  ### Overview

Prevents newly created games from reconnecting players to an old board state when the same host and opponent play again.

  ### Changes

  - Adds a dedicated prepareNewGame cleanup path.
  - Removes any previous game room using the same player-pair game ID.
  - Cancels scheduled tasks belonging to the previous room.
  - Clears stale WebSocket session-to-room mappings.
  - Preserves unrelated active games and sessions.
  - Runs cleanup before starting games through:
      - Player-created rooms
      - Accepted game invitations
      - Quick Play

  - Ensures newly selected decks are loaded when the replacement game is created.

  ### Tests

  Adds regression coverage confirming:

  - Previous same-ID rooms are removed.
  - Previous scheduled tasks are cancelled.
  - Stale session mappings are cleared.
  - Unrelated active games remain unchanged.
  - Cleanup is safe when no previous room exists.

  All four regression tests pass.