### PR TITLE
Create Player Status from Dropdown 

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -40,6 +40,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     private final CardService cardService;
 
     private final Set<WebSocketSession> globalActiveSessions = ConcurrentHashMap.newKeySet();
+    private final Map<WebSocketSession, PlayerStatus> playerStatuses = new ConcurrentHashMap<>();
     private final Set<Room> rooms = ConcurrentHashMap.newKeySet();
     private final Set<PendingGameInvite> pendingGameInvites = ConcurrentHashMap.newKeySet();
 
@@ -68,6 +69,13 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         lastHeartbeatTimestamps.put(session, System.currentTimeMillis());
 
         String username = principal.getName();
+        PlayerStatus initialStatus = getRequestedPlayerStatus(session);
+
+        if (initialStatus != PlayerStatus.LOBBY) {
+            registerActiveSession(session, username, initialStatus);
+            broadcastUserCount();
+            return;
+        }
 
         String activeDeck = mongoUserDetailsService.getActiveDeck(username);
         if (activeDeck.isEmpty() || deckService.getDeckById(activeDeck) == null) {
@@ -82,7 +90,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             return;
         }
 
-        globalActiveSessions.removeIf(s -> Objects.equals(Objects.requireNonNull(s.getPrincipal()).getName(), username));
+        registerActiveSession(session, username, PlayerStatus.LOBBY);
+        broadcastUserCount();
         if (tryReconnectToRoom(session)) return; // Try to reconnect first
 
         List<String> userBlockedAccounts = mongoUserDetailsService.getBlockedAccounts(username);
@@ -97,7 +106,6 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
         sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
 
-        globalActiveSessions.add(session);
     }
 
     @Override
@@ -132,6 +140,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         quickPlayQueue.remove(session);
 
         globalActiveSessions.remove(session);
+        playerStatuses.remove(session);
+        broadcastUserCount();
     }
 
 
@@ -141,6 +151,11 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (payload.equals("/heartbeat/")) {
             lastHeartbeatTimestamps.put(session, System.currentTimeMillis());
+            return;
+        }
+
+        if (payload.startsWith("/setPlayerStatus:")) {
+            setPlayerStatus(session, payload.substring("/setPlayerStatus:".length()));
             return;
         }
 
@@ -452,18 +467,89 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     }
 
     private void broadcastUserCount() throws IOException {
-        List<String> lobbyPlayers = globalActiveSessions.stream()
-                .map(WebSocketSession::getPrincipal)
-                .filter(Objects::nonNull)
-                .map(Principal::getName)
-                .sorted(String.CASE_INSENSITIVE_ORDER)
+        Map<String, PlayerStatus> onlinePlayerStatuses = new HashMap<>();
+
+        globalActiveSessions.stream()
+                .filter(session -> session.getPrincipal() != null)
+                .forEach(session -> onlinePlayerStatuses.put(
+                        Objects.requireNonNull(session.getPrincipal()).getName(),
+                        playerStatuses.getOrDefault(session, PlayerStatus.LOBBY)
+                ));
+
+        rooms.stream()
+                .filter(room -> room.getPlayers().size() >= 2)
+                .flatMap(room -> room.getPlayers().stream())
+                .forEach(player -> onlinePlayerStatuses.put(player.getName(), PlayerStatus.GAME_ROOM));
+
+        gameWebSocket.gameRooms.values().forEach(gameRoom -> {
+            onlinePlayerStatuses.put(gameRoom.getPlayer1().username(), PlayerStatus.MATCH);
+            onlinePlayerStatuses.put(gameRoom.getPlayer2().username(), PlayerStatus.MATCH);
+        });
+
+        List<OnlinePlayerDTO> onlinePlayers = onlinePlayerStatuses.entrySet().stream()
+                .map(entry -> new OnlinePlayerDTO(entry.getKey(), entry.getValue().displayText))
+                .sorted(Comparator.comparing(OnlinePlayerDTO::name, String.CASE_INSENSITIVE_ORDER))
                 .toList();
-        String lobbyPlayersMessage = "[LOBBY_PLAYERS]:" + objectMapper.writeValueAsString(lobbyPlayers);
+        String lobbyPlayersMessage = "[LOBBY_PLAYERS]:" + objectMapper.writeValueAsString(onlinePlayers);
 
         for (WebSocketSession session : globalActiveSessions) {
             sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
             sendTextMessage(session, "[USER_COUNT_QUICK_PLAY]:" + quickPlayQueue.size());
             sendTextMessage(session, lobbyPlayersMessage);
+        }
+    }
+
+    private void setPlayerStatus(WebSocketSession session, String requestedStatus) throws IOException {
+        try {
+            PlayerStatus status = PlayerStatus.valueOf(requestedStatus);
+            if (status == PlayerStatus.MATCH || status == PlayerStatus.GAME_ROOM) return;
+            playerStatuses.put(session, status);
+            broadcastUserCount();
+        } catch (IllegalArgumentException ignored) {
+            // Ignore unknown client-provided statuses.
+        }
+    }
+
+    private void registerActiveSession(WebSocketSession session, String username, PlayerStatus status) {
+        globalActiveSessions.removeIf(existingSession -> {
+            boolean belongsToUser = existingSession.getPrincipal() != null &&
+                    Objects.equals(existingSession.getPrincipal().getName(), username);
+            if (belongsToUser) playerStatuses.remove(existingSession);
+            return belongsToUser;
+        });
+        playerStatuses.put(session, status);
+        globalActiveSessions.add(session);
+    }
+
+    private PlayerStatus getRequestedPlayerStatus(WebSocketSession session) {
+        if (session.getUri() == null || session.getUri().getQuery() == null) return PlayerStatus.LOBBY;
+
+        return Arrays.stream(session.getUri().getQuery().split("&"))
+                .filter(parameter -> parameter.startsWith("status="))
+                .map(parameter -> parameter.substring("status=".length()))
+                .map(status -> {
+                    try {
+                        PlayerStatus parsedStatus = PlayerStatus.valueOf(status);
+                        return parsedStatus == PlayerStatus.MATCH ? PlayerStatus.LOBBY : parsedStatus;
+                    } catch (IllegalArgumentException ignored) {
+                        return PlayerStatus.LOBBY;
+                    }
+                })
+                .findFirst()
+                .orElse(PlayerStatus.LOBBY);
+    }
+
+    private enum PlayerStatus {
+        LOBBY("In lobby"),
+        GAME_ROOM("In Game Room"),
+        MATCH("In a match"),
+        DECKBUILDING("Deck building"),
+        TESTING("Testing");
+
+        private final String displayText;
+
+        PlayerStatus(String displayText) {
+            this.displayText = displayText;
         }
     }
 
@@ -545,7 +631,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             sendRoomUpdate(room, true);
         }
 
-            broadcastRooms();
+        broadcastRooms();
+        broadcastUserCount();
     }
 
     private void handleJoinRoomAttempt(WebSocketSession session, String roomId) throws IOException {
@@ -632,6 +719,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
         sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: You have left the room " + room.getName() + ".");
         broadcastRooms();
+        broadcastUserCount();
     }
 
     private void toggleReady(WebSocketSession session, String roomId) throws IOException {
@@ -689,6 +777,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: You have kicked " + userName + ".");
 
         broadcastRooms();
+        broadcastUserCount();
     }
 
     private void handleChatMessage(WebSocketSession session, String payload) throws IOException {

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/OnlinePlayerDTO.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/OnlinePlayerDTO.java
@@ -1,0 +1,4 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+public record OnlinePlayerDTO(String name, String status) {
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/TestWebSocketSession.java
@@ -1,0 +1,124 @@
+package com.github.wekaito.backend.websocket;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestWebSocketSession implements WebSocketSession {
+    private final String id;
+    private final Principal principal;
+    private final URI uri;
+    private final List<String> messages = new ArrayList<>();
+    private boolean open = true;
+    private int textMessageSizeLimit;
+    private int binaryMessageSizeLimit;
+
+    public TestWebSocketSession(String id, String username) {
+        this(id, username, URI.create("ws://localhost/api/ws/lobby"));
+    }
+
+    public TestWebSocketSession(String id, String username, URI uri) {
+        this.id = id;
+        this.principal = () -> username;
+        this.uri = uri;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public HttpHeaders getHandshakeHeaders() {
+        return HttpHeaders.EMPTY;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+        return null;
+    }
+
+    @Override
+    public String getAcceptedProtocol() {
+        return null;
+    }
+
+    @Override
+    public void setTextMessageSizeLimit(int messageSizeLimit) {
+        textMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getTextMessageSizeLimit() {
+        return textMessageSizeLimit;
+    }
+
+    @Override
+    public void setBinaryMessageSizeLimit(int messageSizeLimit) {
+        binaryMessageSizeLimit = messageSizeLimit;
+    }
+
+    @Override
+    public int getBinaryMessageSizeLimit() {
+        return binaryMessageSizeLimit;
+    }
+
+    @Override
+    public List<WebSocketExtension> getExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public void sendMessage(WebSocketMessage<?> message) {
+        messages.add(message.getPayload().toString());
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+
+    @Override
+    public void close(CloseStatus status) {
+        open = false;
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyPlayerStatusTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyPlayerStatusTest.java
@@ -1,0 +1,159 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+import com.github.wekaito.backend.websocket.TestWebSocketSession;
+import com.github.wekaito.backend.websocket.game.GameWebSocket;
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LobbyPlayerStatusTest {
+    private LobbyWebSocket lobbyWebSocket;
+    private GameWebSocket gameWebSocket;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lobbyWebSocket = new LobbyWebSocket(null, null, null);
+        gameWebSocket = new GameWebSocket(null, null, null);
+
+        Field gameWebSocketField = LobbyWebSocket.class.getDeclaredField("gameWebSocket");
+        gameWebSocketField.setAccessible(true);
+        gameWebSocketField.set(lobbyWebSocket, gameWebSocket);
+    }
+
+    @Test
+    void deckPageConnectionReportsDeckBuildingStatus() throws Exception {
+        TestWebSocketSession session = presenceSession("Aaron", "DECKBUILDING");
+
+        lobbyWebSocket.afterConnectionEstablished(session);
+
+        assertThat(playerListMessage(session)).contains(playerJson("Aaron", "Deck building"));
+    }
+
+    @Test
+    void testPageConnectionReportsTestingStatus() throws Exception {
+        TestWebSocketSession session = presenceSession("Aaron", "TESTING");
+
+        lobbyWebSocket.afterConnectionEstablished(session);
+
+        assertThat(playerListMessage(session)).contains(playerJson("Aaron", "Testing"));
+    }
+
+    @Test
+    void twoPlayersInCreatedRoomBothReportGameRoomStatus() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        TestWebSocketSession guest = lobbySession("Beatrice", "lobby-2");
+        registerLobbySessions(host, guest);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(host, "Aaron", true),
+                        new LobbyPlayer(guest, "Beatrice", false)
+                ))
+        ));
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host))
+                .contains(playerJson("Aaron", "In Game Room"))
+                .contains(playerJson("Beatrice", "In Game Room"));
+    }
+
+    @Test
+    void playerWaitingAloneInCreatedRoomRemainsInLobby() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        registerLobbySessions(host);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(new LobbyPlayer(host, "Aaron", true)))
+        ));
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host)).contains(playerJson("Aaron", "In lobby"));
+    }
+
+    @Test
+    void activeMatchTakesPrecedenceOverGameRoomStatus() throws Exception {
+        TestWebSocketSession host = lobbySession("Aaron", "lobby-1");
+        TestWebSocketSession guest = lobbySession("Beatrice", "lobby-2");
+        registerLobbySessions(host, guest);
+        lobbyWebSocket.getRooms().add(new Room(
+                "room-1",
+                "Test room",
+                "Aaron",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(host, "Aaron", true),
+                        new LobbyPlayer(guest, "Beatrice", false)
+                ))
+        ));
+        GameRoom gameRoom = new GameRoom(
+                "Aaron‗Beatrice",
+                new Player("Aaron", "", "", ""),
+                List.of(),
+                List.of(),
+                new Player("Beatrice", "", "", ""),
+                List.of(),
+                List.of()
+        );
+        gameWebSocket.getGameRooms().put(gameRoom.getRoomId(), gameRoom);
+
+        requestStatusBroadcast(host);
+
+        assertThat(playerListMessage(host))
+                .contains(playerJson("Aaron", "In a match"))
+                .contains(playerJson("Beatrice", "In a match"));
+    }
+
+    private TestWebSocketSession presenceSession(String username, String status) {
+        return new TestWebSocketSession(
+                "presence-" + username,
+                username,
+                URI.create("ws://localhost/api/ws/lobby?status=" + status)
+        );
+    }
+
+    private TestWebSocketSession lobbySession(String username, String id) {
+        return new TestWebSocketSession(id, username);
+    }
+
+    private void registerLobbySessions(TestWebSocketSession... sessions) throws Exception {
+        for (TestWebSocketSession session : sessions) {
+            lobbyWebSocket.getGlobalActiveSessions().add(session);
+            lobbyWebSocket.handleTextMessage(session, new TextMessage("/setPlayerStatus:LOBBY"));
+        }
+    }
+
+    private void requestStatusBroadcast(TestWebSocketSession session) throws Exception {
+        lobbyWebSocket.handleTextMessage(session, new TextMessage("/setPlayerStatus:LOBBY"));
+    }
+
+    private String playerListMessage(TestWebSocketSession session) {
+        return session.getMessages().stream()
+                .filter(message -> message.startsWith("[LOBBY_PLAYERS]:"))
+                .reduce((first, second) -> second)
+                .orElseThrow();
+    }
+
+    private String playerJson(String name, String status) {
+        return "{\"name\":\"" + name + "\",\"status\":\"" + status + "\"}";
+    }
+}

--- a/frontend/src/components/Card.test.tsx
+++ b/frontend/src/components/Card.test.tsx
@@ -29,7 +29,23 @@ function makeCard(keywords: string[]): CardTypeGame {
 
 function renderCard(card: CardTypeGame) {
     useGameBoardStates.setState({ [LOCATION]: [card] } as never);
+    return renderCardView(card);
+}
+
+function renderCardView(card: CardTypeGame) {
     return render(
+        <DndProvider backend={HTML5Backend}>
+            <Card card={card} location={LOCATION} index={0} />
+        </DndProvider>
+    );
+}
+
+function getStoredCard() {
+    return (useGameBoardStates.getState()[LOCATION] as CardTypeGame[])[0];
+}
+
+function cardView(card: CardTypeGame) {
+    return (
         <DndProvider backend={HTML5Backend}>
             <Card card={card} location={LOCATION} index={0} />
         </DndProvider>
@@ -61,7 +77,7 @@ describe("Card keyword animations", () => {
 
     it("clears the SICK animation when the keyword is removed", () => {
         const card = makeCard(["SICK"]);
-        renderCard(card);
+        const view = renderCard(card);
         expect(screen.getByAltText("suspended")).toBeInTheDocument();
 
         act(() => {
@@ -70,13 +86,14 @@ describe("Card keyword animations", () => {
                 keywords: [],
             });
         });
+        view.rerender(cardView(getStoredCard()));
 
         expect(screen.queryByAltText("suspended")).not.toBeInTheDocument();
     });
 
     it("clears the TAUNT animation when the keyword is removed", () => {
         const card = makeCard(["TAUNT"]);
-        renderCard(card);
+        const view = renderCard(card);
         expect(screen.getByTestId("taunt-pulse-overlay")).toBeInTheDocument();
 
         act(() => {
@@ -85,13 +102,14 @@ describe("Card keyword animations", () => {
                 keywords: [],
             });
         });
+        view.rerender(cardView(getStoredCard()));
 
         expect(screen.queryByTestId("taunt-pulse-overlay")).not.toBeInTheDocument();
     });
 
     it("switches from the SICK animation to the TAUNT animation when keywords change", () => {
         const card = makeCard(["SICK"]);
-        renderCard(card);
+        const view = renderCard(card);
         expect(screen.getByAltText("suspended")).toBeInTheDocument();
 
         act(() => {
@@ -100,6 +118,7 @@ describe("Card keyword animations", () => {
                 keywords: ["TAUNT"],
             });
         });
+        view.rerender(cardView(getStoredCard()));
 
         expect(screen.queryByAltText("suspended")).not.toBeInTheDocument();
         expect(screen.getByTestId("taunt-pulse-overlay")).toBeInTheDocument();

--- a/frontend/src/components/lobby/OnlinePlayerListItem.test.tsx
+++ b/frontend/src/components/lobby/OnlinePlayerListItem.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import OnlinePlayerListItem from "./OnlinePlayerListItem";
+
+describe("OnlinePlayerListItem", () => {
+    it("renders the status underneath the player name", () => {
+        render(
+            <ul>
+                <OnlinePlayerListItem name="AgumonFan" status="In lobby" />
+            </ul>
+        );
+
+        const name = screen.getByText("AgumonFan");
+        const status = screen.getByText("In lobby");
+
+        expect(name.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(status).toHaveStyle({ display: "block" });
+    });
+
+    it("uses the online-player status typography", () => {
+        render(
+            <ul>
+                <OnlinePlayerListItem name="GabumonFan" status="Deck building" />
+            </ul>
+        );
+
+        expect(screen.getByText("Deck building")).toHaveStyle({
+            color: "rgba(255, 239, 213, 0.62)",
+            fontFamily: '"Cousine", monospace',
+            fontSize: "0.6em",
+            marginRight: "6px",
+            whiteSpace: "nowrap",
+        });
+    });
+});

--- a/frontend/src/components/lobby/OnlinePlayerListItem.tsx
+++ b/frontend/src/components/lobby/OnlinePlayerListItem.tsx
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+
+type OnlinePlayerListItemProps = {
+    name: string;
+    status: string;
+};
+
+export default function OnlinePlayerListItem({ name, status }: OnlinePlayerListItemProps) {
+    return (
+        <ListItem>
+            <span>{name}</span>
+            <PlayerStatus>{status}</PlayerStatus>
+        </ListItem>
+    );
+}
+
+const ListItem = styled.li`
+    padding: 9px 16px;
+    color: ghostwhite;
+    font-size: 17px;
+`;
+
+const PlayerStatus = styled.span`
+    display: block;
+    color: rgba(255, 239, 213, 0.62);
+    font-family: "Cousine", monospace;
+    font-size: 0.6em;
+    margin-right: 6px;
+    white-space: nowrap;
+`;

--- a/frontend/src/hooks/usePlayerPresence.ts
+++ b/frontend/src/hooks/usePlayerPresence.ts
@@ -1,0 +1,21 @@
+import useWebSocket from "react-use-websocket";
+
+export type PlayerStatus = "LOBBY" | "DECKBUILDING" | "TESTING";
+
+export default function usePlayerPresence(status: PlayerStatus) {
+    const currentPort = window.location.port;
+    const currentUrl = window.location.origin.replace("https://", "");
+    const websocketBaseURL =
+        currentPort === "5173" ? "ws://localhost:8080/api/ws/lobby" : `wss://${currentUrl}/api/ws/lobby`;
+    const websocketURL = `${websocketBaseURL}?status=${status}`;
+
+    useWebSocket(websocketURL, {
+        shouldReconnect: () => true,
+        onOpen: (event) => (event.target as WebSocket).send(`/setPlayerStatus:${status}`),
+        onMessage: (event) => {
+            if (typeof event.data === "string" && event.data.startsWith("[USER_COUNT]:")) {
+                (event.target as WebSocket).send("/heartbeat/");
+            }
+        },
+    });
+}

--- a/frontend/src/pages/DeckTest.tsx
+++ b/frontend/src/pages/DeckTest.tsx
@@ -33,8 +33,11 @@ import { useDeckStates } from "../hooks/useDeckStates.ts";
 import { useNavigate } from "react-router-dom";
 import DeckPanel from "../components/deckPanel/DeckPanel.tsx";
 import axios from "axios";
+import usePlayerPresence from "../hooks/usePlayerPresence.ts";
 
 export default function DeckTest() {
+    usePlayerPresence("TESTING");
+
     const selectCard = useGeneralStates((state) => state.selectCard);
     const selectedCard = useGeneralStates((state) => state.selectedCard);
     const hoverCard = useGeneralStates((state) => state.hoverCard);
@@ -586,7 +589,9 @@ export default function DeckTest() {
     const boardContainerRef = useRef<HTMLDivElement>(null);
     const height = boardContainerRef.current ? Math.max(window.outerHeight - 148, 800) : undefined;
 
-    useLayoutEffect(() => window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0), []);
+    useLayoutEffect(() => {
+        window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0);
+    }, []);
 
     // Determine backend based on touch capability
     const backend = "ontouchstart" in window ? TouchBackend : HTML5Backend;

--- a/frontend/src/pages/Decks.tsx
+++ b/frontend/src/pages/Decks.tsx
@@ -11,8 +11,11 @@ import { useNavigate } from "react-router-dom";
 import BackButton from "../components/BackButton.tsx";
 import { useDeckStates } from "../hooks/useDeckStates.ts";
 import SectionHeadline from "../components/SectionHeadline.tsx";
+import usePlayerPresence from "../hooks/usePlayerPresence.ts";
 
 export default function Decks() {
+    usePlayerPresence("DECKBUILDING");
+
     const loadOrderedDecks = useDeckStates((state) => state.loadOrderedDecks);
     const deckIdOrder = useDeckStates((state) => state.deckIdOrder);
     const setDeckIdOrder = useDeckStates((state) => state.setDeckIdOrder);
@@ -41,7 +44,9 @@ export default function Decks() {
     }
 
     const stableLoadOrderedDecks = useCallback(() => loadOrderedDecks(setOrderedDecks), [loadOrderedDecks]);
-    useLayoutEffect(() => stableLoadOrderedDecks(), [stableLoadOrderedDecks]);
+    useLayoutEffect(() => {
+        stableLoadOrderedDecks();
+    }, [stableLoadOrderedDecks]);
 
     useLayoutEffect(() => {
         if (!isLoading && orderedDecks.length < 16) setRenderAddButton(true);

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -80,6 +80,11 @@ type LobbyPlayer = {
     ready: boolean;
 };
 
+type OnlinePlayer = {
+    name: string;
+    status: string;
+};
+
 type Room = {
     id: string;
     name: string;
@@ -118,7 +123,7 @@ export default function Lobby() {
     const [isAlreadyOpenedInOtherTab, setIsAlreadyOpenedInOtherTab] = useState<boolean>(false);
 
     const [userCount, setUserCount] = useState<number>(0);
-    const [lobbyPlayers, setLobbyPlayers] = useState<string[]>([]);
+    const [lobbyPlayers, setLobbyPlayers] = useState<OnlinePlayer[]>([]);
     const [onlineUsersAnchor, setOnlineUsersAnchor] = useState<HTMLButtonElement | null>(null);
     const [isPlayerSearchOpen, setIsPlayerSearchOpen] = useState(false);
     const [playerSearch, setPlayerSearch] = useState("");
@@ -199,7 +204,7 @@ export default function Lobby() {
                 }
 
                 if (event.data.startsWith("[LOBBY_PLAYERS]:")) {
-                    setLobbyPlayers(JSON.parse(event.data.substring("[LOBBY_PLAYERS]:".length)) as string[]);
+                    setLobbyPlayers(JSON.parse(event.data.substring("[LOBBY_PLAYERS]:".length)) as OnlinePlayer[]);
                 }
 
                 if (event.data.startsWith("[ROOMS]:")) {
@@ -408,6 +413,7 @@ export default function Lobby() {
     }, [playerSearch]);
 
     useEffect(() => {
+        if (!activeDeckId) return;
         axios.get(`/api/profile/decks/${activeDeckId}`).then((res) => setDeckObject(res.data as DeckType));
     }, [activeDeckId]);
 
@@ -432,7 +438,7 @@ export default function Lobby() {
 
     const isMobile = useMediaQuery("(max-width:499px)");
     const filteredLobbyPlayers = lobbyPlayers.filter((player) =>
-        player.toLowerCase().includes(debouncedPlayerSearch.trim().toLowerCase())
+        player.name.toLowerCase().includes(debouncedPlayerSearch.trim().toLowerCase())
     );
     const notifications: AppNotification[] = incomingGameInvites.map((inviter) => ({
         id: `game-invite:${inviter}`,
@@ -577,7 +583,10 @@ export default function Lobby() {
                         </LobbyPlayerListHeading>
                         {filteredLobbyPlayers.length ? (
                             filteredLobbyPlayers.map((player) => (
-                                <LobbyPlayerListItem key={player}>{player}</LobbyPlayerListItem>
+                                <LobbyPlayerListItem key={player.name}>
+                                    {player.name}
+                                    <LobbyPlayerStatus>{player.status}</LobbyPlayerStatus>
+                                </LobbyPlayerListItem>
                             ))
                         ) : (
                             <LobbyPlayerListItem>
@@ -966,6 +975,15 @@ const LobbyPlayerListItem = styled.li`
     padding: 9px 16px;
     color: ghostwhite;
     font-size: 17px;
+`;
+
+const LobbyPlayerStatus = styled.span`
+    display: block;
+    color: rgba(255, 239, 213, 0.62);
+    font-family: "Cousine", monospace;
+    font-size: 0.6em;
+    margin-right: 6px;
+    white-space: nowrap;
 `;
 
 const LeftColumn = styled.div`

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -49,6 +49,7 @@ import ChatContextMenu from "../components/lobby/ChatContextMenu.tsx";
 import { AppNotification, NotificationBell } from "./MainMenu.tsx";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
+import OnlinePlayerListItem from "../components/lobby/OnlinePlayerListItem.tsx";
 
 function ensureChatTimestamp(chatMessage: ChatMessage): ChatMessage {
     return {
@@ -583,10 +584,7 @@ export default function Lobby() {
                         </LobbyPlayerListHeading>
                         {filteredLobbyPlayers.length ? (
                             filteredLobbyPlayers.map((player) => (
-                                <LobbyPlayerListItem key={player.name}>
-                                    {player.name}
-                                    <LobbyPlayerStatus>{player.status}</LobbyPlayerStatus>
-                                </LobbyPlayerListItem>
+                                <OnlinePlayerListItem key={player.name} name={player.name} status={player.status} />
                             ))
                         ) : (
                             <LobbyPlayerListItem>
@@ -975,15 +973,6 @@ const LobbyPlayerListItem = styled.li`
     padding: 9px 16px;
     color: ghostwhite;
     font-size: 17px;
-`;
-
-const LobbyPlayerStatus = styled.span`
-    display: block;
-    color: rgba(255, 239, 213, 0.62);
-    font-family: "Cousine", monospace;
-    font-size: 0.6em;
-    margin-right: 6px;
-    white-space: nowrap;
 `;
 
 const LeftColumn = styled.div`

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,25 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
+
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+    get length() {
+        return storage.size;
+    },
+    clear: () => storage.clear(),
+    getItem: (key) => storage.get(key) ?? null,
+    key: (index) => Array.from(storage.keys())[index] ?? null,
+    removeItem: (key) => storage.delete(key),
+    setItem: (key, value) => storage.set(key, String(value)),
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorageMock,
+});
+
+beforeEach(() => localStorage.clear());
 
 afterEach(() => cleanup());
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,8 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => cleanup());
 
 // lottie-web touches the canvas 2D context at import time; jsdom doesn't
 // implement it, so stub a minimal no-op context to avoid crashing imports.


### PR DESCRIPTION
## Summary

  - Track player presence: lobby, game room, match, deck building, testing.
  - Broadcast player name/status objects through lobby WebSocket.
  - Display status beneath player name.
  - Add presence hook for deck builder/test pages.
  - Prevent empty active-deck request.
  - Add backend WebSocket status tests.
  - Add frontend status layout/style tests.
  - Fix shared jsdom, localStorage, cleanup setup.
  - Fix Card tests to rerender updated Zustand state.

  ## Testing

  - Frontend: 13/13 passing.
  - Backend: player status scenarios covered.
  - Verified local and Docker test runs.

<img width="370" height="327" alt="Screenshot 2026-07-20 at 9 51 09 PM" src="https://github.com/user-attachments/assets/a529e84e-4086-426a-8022-1699484e1547" />

