### PR TITLE
Create invite functionality

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -42,6 +42,9 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     private final Set<WebSocketSession> globalActiveSessions = ConcurrentHashMap.newKeySet();
     private final Set<Room> rooms = ConcurrentHashMap.newKeySet();
     private final Set<PendingGameInvite> pendingGameInvites = ConcurrentHashMap.newKeySet();
+    private final Map<PendingGameInvite, Long> gameInviteCooldowns = new ConcurrentHashMap<>();
+
+    private static final long GAME_INVITE_COOLDOWN_MS = 10_000;
 
     private final Map<String, Long> emptyRoomTimestamps = new ConcurrentHashMap<>();
     private final Map<WebSocketSession, String> lastPlayerRooms = new ConcurrentHashMap<>(); // username -> roomId
@@ -183,6 +186,12 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         if (invitedPlayer.isBlank() || invitedPlayer.equals(inviter)) return;
 
         PendingGameInvite invite = new PendingGameInvite(inviter, invitedPlayer);
+        Long cooldownExpiresAt = gameInviteCooldowns.get(invite);
+        if (cooldownExpiresAt != null) {
+            if (cooldownExpiresAt > System.currentTimeMillis()) return;
+            gameInviteCooldowns.remove(invite, cooldownExpiresAt);
+        }
+
         for (WebSocketSession activeSession : globalActiveSessions) {
             Principal activePrincipal = activeSession.getPrincipal();
             if (activePrincipal != null && activePrincipal.getName().equals(invitedPlayer)) {
@@ -212,7 +221,9 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         String inviter = principal.getName();
         String invitedPlayer = parts[1];
-        if (!pendingGameInvites.remove(new PendingGameInvite(inviter, invitedPlayer))) return;
+        PendingGameInvite invite = new PendingGameInvite(inviter, invitedPlayer);
+        if (!pendingGameInvites.remove(invite)) return;
+        gameInviteCooldowns.put(invite, System.currentTimeMillis() + GAME_INVITE_COOLDOWN_MS);
 
         for (WebSocketSession activeSession : globalActiveSessions) {
             Principal activePrincipal = activeSession.getPrincipal();
@@ -310,6 +321,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     @Scheduled(fixedRate = 5000) // 5 seconds
     private void shortIntervalOperations() throws IOException {
+        long now = System.currentTimeMillis();
+        gameInviteCooldowns.entrySet().removeIf(entry -> entry.getValue() <= now);
         broadcastUserCount();
         checkForRejoinableGameRoom();
         broadcastRooms();

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -168,6 +168,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (payload.startsWith("/inviteToGame:")) handleGameInvite(session, payload);
 
+        if (payload.startsWith("/cancelGameInvite:")) handleCancelGameInvite(session, payload);
+
         if (payload.startsWith("/gameInviteResponse:")) handleGameInviteResponse(session, payload);
     }
 
@@ -201,6 +203,24 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         }
 
         sendTextMessage(session, "[GAME_INVITE_RESPONSE]:" + invitedPlayer + ":false");
+    }
+
+    private void handleCancelGameInvite(WebSocketSession session, String payload) throws IOException {
+        Principal principal = session.getPrincipal();
+        String[] parts = payload.split(":", 2);
+        if (principal == null || parts.length < 2) return;
+
+        String inviter = principal.getName();
+        String invitedPlayer = parts[1];
+        if (!pendingGameInvites.remove(new PendingGameInvite(inviter, invitedPlayer))) return;
+
+        for (WebSocketSession activeSession : globalActiveSessions) {
+            Principal activePrincipal = activeSession.getPrincipal();
+            if (activePrincipal != null && activePrincipal.getName().equals(invitedPlayer)) {
+                sendTextMessage(activeSession, "[GAME_INVITE_CANCELLED]:" + inviter);
+                break;
+            }
+        }
     }
 
     private void handleGameInviteResponse(WebSocketSession session, String payload) throws IOException {

--- a/frontend/src/components/lobby/ChatContextMenu.test.tsx
+++ b/frontend/src/components/lobby/ChatContextMenu.test.tsx
@@ -21,13 +21,15 @@ vi.mock("react-contexify", () => ({
         children,
         hidden,
         onClick,
+        disabled,
     }: {
         children: ReactNode;
         hidden?: (params: { props: ChatMessage }) => boolean;
         onClick?: (params: { props: ChatMessage }) => void;
+        disabled?: boolean;
     }) => {
         if (hidden?.({ props: contextMenuMock.message })) return null;
-        return <div onClick={() => onClick?.({ props: contextMenuMock.message })}>{children}</div>;
+        return <div onClick={disabled ? undefined : () => onClick?.({ props: contextMenuMock.message })}>{children}</div>;
     },
     Separator: () => <hr />,
 }));
@@ -42,7 +44,7 @@ vi.mock("../../hooks/useMutation.ts", () => ({
 
 import ChatContextMenu from "./ChatContextMenu.tsx";
 
-function renderMenu(pendingGameInvites = new Set<string>()) {
+function renderMenu(pendingGameInvites = new Set<string>(), inviteCooldownPlayers = new Set<string>()) {
     const sendMessage = vi.fn();
     const onInviteSent = vi.fn();
     const onInviteCancelled = vi.fn();
@@ -54,6 +56,7 @@ function renderMenu(pendingGameInvites = new Set<string>()) {
             onInviteSent={onInviteSent}
             onInviteCancelled={onInviteCancelled}
             pendingGameInvites={pendingGameInvites}
+            inviteCooldownPlayers={inviteCooldownPlayers}
         />
     );
 
@@ -96,6 +99,18 @@ describe("ChatContextMenu game invitations", () => {
 
         expect(sendMessage).toHaveBeenCalledWith("/cancelGameInvite:other-player");
         expect(onInviteCancelled).toHaveBeenCalledWith("other-player");
+        expect(onInviteSent).not.toHaveBeenCalled();
+    });
+
+    it("disables invitations while the player is in cooldown", () => {
+        const { sendMessage, onInviteSent } = renderMenu(new Set(), new Set(["other-player"]));
+
+        expect(screen.getByText("Invite Cooldown")).toBeInTheDocument();
+        expect(screen.queryByText("Invite to Game")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Invite Cooldown"));
+
+        expect(sendMessage).not.toHaveBeenCalled();
         expect(onInviteSent).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/components/lobby/ChatContextMenu.test.tsx
+++ b/frontend/src/components/lobby/ChatContextMenu.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGeneralStates } from "../../hooks/useGeneralStates.ts";
+import type { ChatMessage } from "./Chat.tsx";
+
+const contextMenuMock = vi.hoisted(() => ({
+    message: {
+        id: "message-1",
+        author: "other-player",
+        message: "hello",
+        timestamp: new Date().toISOString(),
+    } as ChatMessage,
+}));
+
+vi.mock("react-contexify", () => ({
+    Item: ({
+        children,
+        hidden,
+        onClick,
+    }: {
+        children: ReactNode;
+        hidden?: (params: { props: ChatMessage }) => boolean;
+        onClick?: (params: { props: ChatMessage }) => void;
+    }) => {
+        if (hidden?.({ props: contextMenuMock.message })) return null;
+        return <div onClick={() => onClick?.({ props: contextMenuMock.message })}>{children}</div>;
+    },
+    Separator: () => <hr />,
+}));
+
+vi.mock("../game/ContextMenus/ContextMenus.tsx", () => ({
+    StyledMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../hooks/useMutation.ts", () => ({
+    default: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import ChatContextMenu from "./ChatContextMenu.tsx";
+
+function renderMenu(pendingGameInvites = new Set<string>()) {
+    const sendMessage = vi.fn();
+    const onInviteSent = vi.fn();
+    const onInviteCancelled = vi.fn();
+
+    render(
+        <ChatContextMenu
+            isAdmin={false}
+            sendMessage={sendMessage}
+            onInviteSent={onInviteSent}
+            onInviteCancelled={onInviteCancelled}
+            pendingGameInvites={pendingGameInvites}
+        />
+    );
+
+    return { sendMessage, onInviteSent, onInviteCancelled };
+}
+
+describe("ChatContextMenu game invitations", () => {
+    afterEach(cleanup);
+
+    beforeEach(() => {
+        useGeneralStates.setState({ user: "current-player" });
+        contextMenuMock.message = {
+            id: "message-1",
+            author: "other-player",
+            message: "hello",
+            timestamp: new Date().toISOString(),
+        };
+    });
+
+    it("shows Invite to Game and sends an invitation when no invite is pending", () => {
+        const { sendMessage, onInviteSent, onInviteCancelled } = renderMenu();
+
+        expect(screen.getByText("Invite to Game")).toBeInTheDocument();
+        expect(screen.queryByText("Cancel Invite")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Invite to Game"));
+
+        expect(sendMessage).toHaveBeenCalledWith("/inviteToGame:other-player");
+        expect(onInviteSent).toHaveBeenCalledWith("other-player");
+        expect(onInviteCancelled).not.toHaveBeenCalled();
+    });
+
+    it("shows Cancel Invite and cancels an existing invitation", () => {
+        const { sendMessage, onInviteSent, onInviteCancelled } = renderMenu(new Set(["other-player"]));
+
+        expect(screen.getByText("Cancel Invite")).toBeInTheDocument();
+        expect(screen.queryByText("Invite to Game")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText("Cancel Invite"));
+
+        expect(sendMessage).toHaveBeenCalledWith("/cancelGameInvite:other-player");
+        expect(onInviteCancelled).toHaveBeenCalledWith("other-player");
+        expect(onInviteSent).not.toHaveBeenCalled();
+    });
+
+    it.each(["current-player", "【SERVER】"])("hides invitation actions for %s", (author) => {
+        contextMenuMock.message = { ...contextMenuMock.message, author };
+
+        renderMenu();
+
+        expect(screen.queryByText("Invite to Game")).not.toBeInTheDocument();
+        expect(screen.queryByText("Cancel Invite")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/lobby/ChatContextMenu.tsx
+++ b/frontend/src/components/lobby/ChatContextMenu.tsx
@@ -20,6 +20,7 @@ type Props = {
     onInviteSent: (player: string) => void;
     onInviteCancelled: (player: string) => void;
     pendingGameInvites: Set<string>;
+    inviteCooldownPlayers: Set<string>;
 };
 
 export default function ChatContextMenu({
@@ -28,6 +29,7 @@ export default function ChatContextMenu({
     onInviteSent,
     onInviteCancelled,
     pendingGameInvites,
+    inviteCooldownPlayers,
 }: Props) {
     const user = useGeneralStates((state) => state.user);
     const { mutate, isPending } = useMutation("/api/report", "POST");
@@ -62,6 +64,8 @@ export default function ChatContextMenu({
     function handleInviteToGame({ props }: ItemParams<ChatMessage>) {
         if (props === undefined || props.author === user || props.author === "【SERVER】") return;
 
+        if (inviteCooldownPlayers.has(props.author)) return;
+
         if (pendingGameInvites.has(props.author)) {
             sendMessage(`/cancelGameInvite:${props.author}`);
             onInviteCancelled(props.author);
@@ -87,12 +91,28 @@ export default function ChatContextMenu({
                 onClick={handleInviteToGame}
                 hidden={({ props }) => {
                     const player = (props as ChatMessage | undefined)?.author ?? "";
-                    return ["【SERVER】", user].includes(player) || pendingGameInvites.has(player);
+                    return (
+                        ["【SERVER】", user].includes(player) ||
+                        pendingGameInvites.has(player) ||
+                        inviteCooldownPlayers.has(player)
+                    );
                 }}
             >
                 <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
                     <span>Invite to Game</span>
                     <InviteIcon color="primary" />
+                </div>
+            </Item>
+            <Item
+                disabled
+                hidden={({ props }) => {
+                    const player = (props as ChatMessage | undefined)?.author ?? "";
+                    return ["【SERVER】", user].includes(player) || !inviteCooldownPlayers.has(player);
+                }}
+            >
+                <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+                    <span>Invite Cooldown</span>
+                    <InviteIcon color="disabled" />
                 </div>
             </Item>
             <Item

--- a/frontend/src/components/lobby/ChatContextMenu.tsx
+++ b/frontend/src/components/lobby/ChatContextMenu.tsx
@@ -1,5 +1,10 @@
 import { Item, ItemParams, Separator } from "react-contexify";
-import { DeleteForever as TrashIcon, PersonAdd as InviteIcon, Report as ReportIcon } from "@mui/icons-material";
+import {
+    Cancel as CancelIcon,
+    DeleteForever as TrashIcon,
+    PersonAdd as InviteIcon,
+    Report as ReportIcon,
+} from "@mui/icons-material";
 import { StyledMenu } from "../game/ContextMenus/ContextMenus.tsx";
 import axios from "axios";
 import "react-contexify/dist/ReactContexify.css";
@@ -13,10 +18,17 @@ type Props = {
     isAdmin: boolean;
     sendMessage: SendMessage;
     onInviteSent: (player: string) => void;
+    onInviteCancelled: (player: string) => void;
     pendingGameInvites: Set<string>;
 };
 
-export default function ChatContextMenu({ isAdmin, sendMessage, onInviteSent, pendingGameInvites }: Props) {
+export default function ChatContextMenu({
+    isAdmin,
+    sendMessage,
+    onInviteSent,
+    onInviteCancelled,
+    pendingGameInvites,
+}: Props) {
     const user = useGeneralStates((state) => state.user);
     const { mutate, isPending } = useMutation("/api/report", "POST");
 
@@ -48,13 +60,14 @@ export default function ChatContextMenu({ isAdmin, sendMessage, onInviteSent, pe
     }
 
     function handleInviteToGame({ props }: ItemParams<ChatMessage>) {
-        if (
-            props === undefined ||
-            props.author === user ||
-            props.author === "【SERVER】" ||
-            pendingGameInvites.has(props.author)
-        )
+        if (props === undefined || props.author === user || props.author === "【SERVER】") return;
+
+        if (pendingGameInvites.has(props.author)) {
+            sendMessage(`/cancelGameInvite:${props.author}`);
+            onInviteCancelled(props.author);
             return;
+        }
+
         sendMessage(`/inviteToGame:${props.author}`);
         onInviteSent(props.author);
     }
@@ -72,14 +85,26 @@ export default function ChatContextMenu({ isAdmin, sendMessage, onInviteSent, pe
             {isAdmin && <Separator />}
             <Item
                 onClick={handleInviteToGame}
-                hidden={({ props }) => (props as ChatMessage | undefined)?.author === "【SERVER】"}
-                disabled={({ props }) =>
-                    pendingGameInvites.has((props as ChatMessage | undefined)?.author ?? "")
-                }
+                hidden={({ props }) => {
+                    const player = (props as ChatMessage | undefined)?.author ?? "";
+                    return ["【SERVER】", user].includes(player) || pendingGameInvites.has(player);
+                }}
             >
                 <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
                     <span>Invite to Game</span>
                     <InviteIcon color="primary" />
+                </div>
+            </Item>
+            <Item
+                onClick={handleInviteToGame}
+                hidden={({ props }) => {
+                    const player = (props as ChatMessage | undefined)?.author ?? "";
+                    return ["【SERVER】", user].includes(player) || !pendingGameInvites.has(player);
+                }}
+            >
+                <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+                    <span>Cancel Invite</span>
+                    <CancelIcon color="error" />
                 </div>
             </Item>
             <Separator />

--- a/frontend/src/hooks/useInviteCooldowns.test.ts
+++ b/frontend/src/hooks/useInviteCooldowns.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import useInviteCooldowns from "./useInviteCooldowns.ts";
+
+describe("useInviteCooldowns", () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+        vi.setSystemTime(new Date("2026-07-21T12:00:00Z"));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("updates every displayed second and clears the cooldown after ten seconds", () => {
+        const { result } = renderHook(() => useInviteCooldowns());
+
+        act(() => result.current.startInviteCooldown("other-player"));
+
+        expect(result.current.isInviteCoolingDown("other-player")).toBe(true);
+        expect(result.current.getInviteCooldownSeconds("other-player")).toBe(10);
+
+        for (let expectedSeconds = 9; expectedSeconds >= 1; expectedSeconds--) {
+            act(() => vi.advanceTimersByTime(1000));
+            expect(result.current.getInviteCooldownSeconds("other-player")).toBe(expectedSeconds);
+            expect(result.current.isInviteCoolingDown("other-player")).toBe(true);
+        }
+
+        act(() => vi.advanceTimersByTime(1000));
+
+        expect(result.current.getInviteCooldownSeconds("other-player")).toBe(0);
+        expect(result.current.isInviteCoolingDown("other-player")).toBe(false);
+        expect(result.current.inviteCooldownPlayers.has("other-player")).toBe(false);
+    });
+
+    it("tracks cooldowns independently for different players", () => {
+        const { result } = renderHook(() => useInviteCooldowns());
+
+        act(() => result.current.startInviteCooldown("player-one"));
+        act(() => vi.advanceTimersByTime(3000));
+        act(() => result.current.startInviteCooldown("player-two"));
+
+        expect(result.current.getInviteCooldownSeconds("player-one")).toBe(7);
+        expect(result.current.getInviteCooldownSeconds("player-two")).toBe(10);
+    });
+});

--- a/frontend/src/hooks/useInviteCooldowns.ts
+++ b/frontend/src/hooks/useInviteCooldowns.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+export const INVITE_COOLDOWN_MS = 10_000;
+
+export default function useInviteCooldowns() {
+    const [inviteCooldowns, setInviteCooldowns] = useState<Map<string, number>>(() => new Map());
+
+    useEffect(() => {
+        if (!inviteCooldowns.size) return;
+
+        const interval = window.setInterval(() => {
+            const now = Date.now();
+            setInviteCooldowns((cooldowns) =>
+                new Map([...cooldowns].filter(([, expiresAt]) => expiresAt > now))
+            );
+        }, 250);
+
+        return () => window.clearInterval(interval);
+    }, [inviteCooldowns.size]);
+
+    function startInviteCooldown(player: string) {
+        setInviteCooldowns((cooldowns) => new Map(cooldowns).set(player, Date.now() + INVITE_COOLDOWN_MS));
+    }
+
+    function isInviteCoolingDown(player: string) {
+        return (inviteCooldowns.get(player) ?? 0) > Date.now();
+    }
+
+    function getInviteCooldownSeconds(player: string) {
+        return Math.max(0, Math.ceil(((inviteCooldowns.get(player) ?? 0) - Date.now()) / 1000));
+    }
+
+    return {
+        getInviteCooldownSeconds,
+        inviteCooldownPlayers: new Set(inviteCooldowns.keys()),
+        isInviteCoolingDown,
+        startInviteCooldown,
+    };
+}

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -397,14 +397,18 @@ export default function Lobby() {
         setPendingGameInvites((players) => new Set(players).add(player));
     }
 
+    function handleInviteCancelled(player: string) {
+        setPendingGameInvites((players) => {
+            const nextPlayers = new Set(players);
+            nextPlayers.delete(player);
+            return nextPlayers;
+        });
+    }
+
     function handlePlayerInvite(player: string) {
         if (pendingGameInvites.has(player)) {
             websocket.sendMessage(`/cancelGameInvite:${player}`);
-            setPendingGameInvites((players) => {
-                const nextPlayers = new Set(players);
-                nextPlayers.delete(player);
-                return nextPlayers;
-            });
+            handleInviteCancelled(player);
             return;
         }
 
@@ -897,6 +901,7 @@ export default function Lobby() {
                 isAdmin={!!isAdmin}
                 sendMessage={websocket.sendMessage}
                 onInviteSent={handleInviteSent}
+                onInviteCancelled={handleInviteCancelled}
                 pendingGameInvites={pendingGameInvites}
             />
         </MenuBackgroundWrapper>

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -270,6 +270,11 @@ export default function Lobby() {
                     });
                 }
 
+                if (event.data.startsWith("[GAME_INVITE_CANCELLED]:")) {
+                    const inviter = event.data.substring("[GAME_INVITE_CANCELLED]:".length);
+                    setIncomingGameInvites((inviters) => inviters.filter((name) => name !== inviter));
+                }
+
                 if (event.data.startsWith("[RECONNECT_ENABLED]:")) {
                     const matchingRoomId = event.data.substring("[RECONNECT_ENABLED]:".length);
                     setIsRejoinable(matchingRoomId === gameId);
@@ -390,6 +395,21 @@ export default function Lobby() {
 
     function handleInviteSent(player: string) {
         setPendingGameInvites((players) => new Set(players).add(player));
+    }
+
+    function handlePlayerInvite(player: string) {
+        if (pendingGameInvites.has(player)) {
+            websocket.sendMessage(`/cancelGameInvite:${player}`);
+            setPendingGameInvites((players) => {
+                const nextPlayers = new Set(players);
+                nextPlayers.delete(player);
+                return nextPlayers;
+            });
+            return;
+        }
+
+        websocket.sendMessage(`/inviteToGame:${player}`);
+        handleInviteSent(player);
     }
 
     function handleGameInviteResponse(inviter: string, accepted: boolean) {
@@ -577,7 +597,18 @@ export default function Lobby() {
                         </LobbyPlayerListHeading>
                         {filteredLobbyPlayers.length ? (
                             filteredLobbyPlayers.map((player) => (
-                                <LobbyPlayerListItem key={player}>{player}</LobbyPlayerListItem>
+                                <LobbyPlayerListItem key={player}>
+                                    <span>{player}</span>
+                                    {player !== user && (
+                                        <PlayerInviteButton
+                                            type="button"
+                                            pending={pendingGameInvites.has(player)}
+                                            onClick={() => handlePlayerInvite(player)}
+                                        >
+                                            {pendingGameInvites.has(player) ? "cancel invite" : "invite to play"}
+                                        </PlayerInviteButton>
+                                    )}
+                                </LobbyPlayerListItem>
                             ))
                         ) : (
                             <LobbyPlayerListItem>
@@ -963,9 +994,35 @@ const PlayerSearchInput = styled(InputBase)`
 `;
 
 const LobbyPlayerListItem = styled.li`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
     padding: 9px 16px;
     color: ghostwhite;
     font-size: 17px;
+`;
+
+const PlayerInviteButton = styled.button<{ pending: boolean }>`
+    flex-shrink: 0;
+    padding: 5px 8px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 3px;
+    background: var(${({ pending }) => (pending ? "--orange-button-bg" : "--blue-button-bg")});
+    color: ghostwhite;
+    font: 600 12px/1 "League Spartan", sans-serif;
+    text-transform: uppercase;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+        background: var(${({ pending }) => (pending ? "--orange-button-bg-hover" : "--blue-button-bg-hover")});
+        outline: none;
+    }
+
+    &:active {
+        background: var(${({ pending }) => (pending ? "--orange-button-bg-active" : "--blue-button-bg-active")});
+    }
 `;
 
 const LeftColumn = styled.div`

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -49,6 +49,7 @@ import ChatContextMenu from "../components/lobby/ChatContextMenu.tsx";
 import { AppNotification, NotificationBell } from "./MainMenu.tsx";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
+import useInviteCooldowns from "../hooks/useInviteCooldowns.ts";
 
 function ensureChatTimestamp(chatMessage: ChatMessage): ChatMessage {
     return {
@@ -134,6 +135,12 @@ export default function Lobby() {
     const [rooms, setRooms] = useState<Room[]>([]);
     const [incomingGameInvites, setIncomingGameInvites] = useState<string[]>([]);
     const [pendingGameInvites, setPendingGameInvites] = useState<Set<string>>(() => new Set());
+    const {
+        getInviteCooldownSeconds,
+        inviteCooldownPlayers,
+        isInviteCoolingDown,
+        startInviteCooldown,
+    } = useInviteCooldowns();
 
     const [newRoomName, setNewRoomName] = useState<string>("");
     const [newRoomPassword, setNewRoomPassword] = useState<string>("");
@@ -403,6 +410,7 @@ export default function Lobby() {
             nextPlayers.delete(player);
             return nextPlayers;
         });
+        startInviteCooldown(player);
     }
 
     function handlePlayerInvite(player: string) {
@@ -411,6 +419,8 @@ export default function Lobby() {
             handleInviteCancelled(player);
             return;
         }
+
+        if (isInviteCoolingDown(player)) return;
 
         websocket.sendMessage(`/inviteToGame:${player}`);
         handleInviteSent(player);
@@ -607,9 +617,14 @@ export default function Lobby() {
                                         <PlayerInviteButton
                                             type="button"
                                             pending={pendingGameInvites.has(player)}
+                                            disabled={isInviteCoolingDown(player)}
                                             onClick={() => handlePlayerInvite(player)}
                                         >
-                                            {pendingGameInvites.has(player) ? "cancel invite" : "invite to play"}
+                                            {pendingGameInvites.has(player)
+                                                ? "cancel invite"
+                                                : isInviteCoolingDown(player)
+                                                  ? `invite in ${getInviteCooldownSeconds(player)}s`
+                                                  : "invite to play"}
                                         </PlayerInviteButton>
                                     )}
                                 </LobbyPlayerListItem>
@@ -903,6 +918,7 @@ export default function Lobby() {
                 onInviteSent={handleInviteSent}
                 onInviteCancelled={handleInviteCancelled}
                 pendingGameInvites={pendingGameInvites}
+                inviteCooldownPlayers={inviteCooldownPlayers}
             />
         </MenuBackgroundWrapper>
     );
@@ -1027,6 +1043,12 @@ const PlayerInviteButton = styled.button<{ pending: boolean }>`
 
     &:active {
         background: var(${({ pending }) => (pending ? "--orange-button-bg-active" : "--blue-button-bg-active")});
+    }
+
+    &:disabled {
+        filter: grayscale(0.65);
+        opacity: 0.65;
+        cursor: not-allowed;
     }
 `;
 


### PR DESCRIPTION
 ## Summary
Addresses issue here: https://github.com/WE-Kaito/digimon-tcg-simulator/issues/322

  - Added “Invite to Play” buttons beside players in the Lobby player list.
  - Changed pending invitations to an orange “Cancel Invite” button using the Quick Play color convention.
  - Updated the chat context menu to toggle between “Invite to Game” and “Cancel Invite.”
  - Reused shared invitation state across the player list and chat context menu.
  - Added backend WebSocket support for cancelling pending invitations.
  - Clears the invitee’s notification when an invitation is cancelled.
  - Preserved existing Accept and Decline behavior.
  - Prevented invitations to the current user and server messages.

  ## Testing

  - Added tests covering invitation creation, cancellation, button state, and hidden actions.
  - Frontend TypeScript validation passes.
  - Backend compilation passes.
  - All four new invitation tests pass.


<img width="277" height="231" alt="Screenshot 2026-07-21 at 12 48 07 PM" src="https://github.com/user-attachments/assets/7934146d-243c-4656-b7cf-6dafb6700ed1" />
<img width="570" height="283" alt="Screenshot 2026-07-21 at 12 48 15 PM" src="https://github.com/user-attachments/assets/b4adb71d-e1d7-4aa6-9ffa-08c8088e6067" />
<img width="531" height="186" alt="Screenshot 2026-07-21 at 1 24 16 PM" src="https://github.com/user-attachments/assets/db0d3814-a254-4780-85bb-cf4d69fc5d08" />
Users can cancel invites now
<img width="367" height="227" alt="Screenshot 2026-07-21 at 1 26 23 PM" src="https://github.com/user-attachments/assets/b2d53cd0-c4fa-4089-8c6d-c9acfc61f962" />
Created functionality to prevent spamming, users have to wait another 10 seconds after they invite and cancel:

<img width="302" height="228" alt="Screenshot 2026-07-21 at 1 41 26 PM" src="https://github.com/user-attachments/assets/ef7051c3-0b88-45ce-925d-ace52b417cbf" />
