### PR TITLE
Prevent DeckTest Scroll Effect Cleanup Error

### DIFF
--- a/frontend/src/pages/DeckTest.tsx
+++ b/frontend/src/pages/DeckTest.tsx
@@ -586,7 +586,9 @@ export default function DeckTest() {
     const boardContainerRef = useRef<HTMLDivElement>(null);
     const height = boardContainerRef.current ? Math.max(window.outerHeight - 148, 800) : undefined;
 
-    useLayoutEffect(() => window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0), []);
+    useEffect(() => {
+        window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0);
+    }, []);
 
     // Determine backend based on touch capability
     const backend = "ontouchstart" in window ? TouchBackend : HTML5Backend;


### PR DESCRIPTION
• ## Summary

<img width="1092" height="720" alt="Screenshot 2026-07-22 at 6 19 17 PM" src="https://github.com/user-attachments/assets/b47338b7-e1e9-47c0-b8b2-90121122af9b" />
This PR fixes the issue where when developing sometimes and when I go to /test, the screen blacks out with this error stack:


  - Replace DeckTest scroll useLayoutEffect with useEffect. Scrolling does not affect DOM measurement before paint, so useLayoutEffect is unnecessary.
  - Use block callback to guarantee no cleanup value returns.
  - Prevent React Strict Mode crash: destroy is not a function.

  ## Testing

  - Verified DeckTest loads without effect cleanup errors.
  - Frontend production build passes.
