### PR TITLE
Fixed CSS for Modifier Menu

### DIFF
--- a/frontend/src/components/game/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/game/ContextMenus/ContextMenus.tsx
@@ -15,7 +15,7 @@ import {
     PreviewRounded as StreamerModeIcon,
     LabelImportant as MarkerIcon,
 } from "@mui/icons-material";
-import { CSSProperties } from "react";
+import { CSSProperties, useCallback, useEffect, useRef } from "react";
 import ModifierMenu from "./ModifierMenu.tsx";
 import { convertForLog, numbersWithModifiers } from "../../../utils/functions.ts";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
@@ -27,6 +27,25 @@ import { WSUtils } from "../../../pages/GamePage.tsx";
 import { OpenedCardDialog, useGameUIStates } from "../../../hooks/useGameUIStates.ts";
 
 export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
+    const previousPageOverflow = useRef<{ body: string; document: string } | null>(null);
+
+    const setPageScrollLocked = useCallback((isLocked: boolean) => {
+        if (isLocked && !previousPageOverflow.current) {
+            previousPageOverflow.current = {
+                body: document.body.style.overflow,
+                document: document.documentElement.style.overflow,
+            };
+            document.body.style.overflow = "hidden";
+            document.documentElement.style.overflow = "hidden";
+        } else if (!isLocked && previousPageOverflow.current) {
+            document.body.style.overflow = previousPageOverflow.current.body;
+            document.documentElement.style.overflow = previousPageOverflow.current.document;
+            previousPageOverflow.current = null;
+        }
+    }, []);
+
+    useEffect(() => () => setPageScrollLocked(false), [setPageScrollLocked]);
+
     const { sendMessage, sendChatMessage, sendSfx, matchInfo, sendMoveCard } = wsUtils ?? {};
 
     const selectedCard = useGeneralStates((state) => state.selectedCard);
@@ -244,7 +263,7 @@ export default function ContextMenus({ wsUtils }: { wsUtils?: WSUtils }) {
                 </Item>
             </StyledMenu>
 
-            <StyledMenu id={"fieldCardMenu"} theme="dark">
+            <StyledMenu id={"fieldCardMenu"} theme="dark" onVisibilityChange={setPageScrollLocked}>
                 <Item onClick={activateEffectAnimation}>
                     <div style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
                         <span>Activate Effect</span> <EffectIcon />

--- a/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
+++ b/frontend/src/components/game/ContextMenus/ModifierMenu.tsx
@@ -52,7 +52,7 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
     const setModifiers = useGameBoardStates((state) => state.setModifiers);
 
     const card = useGameBoardStates((state) =>
-        (state[cardToSend?.location as keyof typeof state] as CardTypeGame[]).find(
+        (state[cardToSend?.location as keyof typeof state] as CardTypeGame[] | undefined)?.find(
             (card) => card.id === cardToSend?.card.id
         )
     );
@@ -207,7 +207,7 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
                             arrow={<StyledLottie style={{ marginLeft: 60 }} animationData={arrowsAnimation} />}
                         >
                             <StyledFieldset>
-                                <Stack maxHeight={432} flexWrap={"wrap"}>
+                                <KeywordList data-testid="keyword-list">
                                     {battleKeywords.map(
                                         (keyword) =>
                                             !keywords.includes(keyword) && (
@@ -227,7 +227,7 @@ export default function ModifierMenu({ sendSetModifiers }: ModifierMenuProps) {
                                                 </Item>
                                             )
                                     )}
-                                </Stack>
+                                </KeywordList>
                             </StyledFieldset>
                         </Submenu>
                         <SubmitItem disabled={!haveModifiersChanged} onClick={handleSubmit}>
@@ -257,6 +257,15 @@ const StyledFieldset = styled.fieldset`
     background: #0c0c0c;
     border-radius: 5px;
     margin: 0;
+`;
+
+const KeywordList = styled.div`
+    display: flex;
+    flex-direction: column;
+    max-height: min(432px, calc(100vh - 48px));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
 `;
 
 const NumericStack = styled(Stack)`


### PR DESCRIPTION
 ## Summary
Addressing Issue here: https://github.com/WE-Kaito/digimon-tcg-simulator/issues/332 

  - Make keyword modifier list vertically scrollable.
  - Prevent horizontal overflow from wrapped keyword columns.
  - Limit menu height based on viewport size.
  - Disable background page scrolling while the modifier menu is open.
  - Restore previous page scroll behavior when the menu closes or unmounts.
  - Safely handle missing card-location state during menu cleanup.

  ## Testing

  - Docker frontend production build passes.
  - Existing modifier tests expose an unrelated DOM cleanup/isolation issue between tests.
<img width="530" height="596" alt="Screenshot 2026-07-22 at 6 49 55 PM" src="https://github.com/user-attachments/assets/006d27d0-ca14-4702-b4aa-495fe08b8997" />

