### PR TITLE
Rework Game Lobby Functionality

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameLobbyReturnEvent.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameLobbyReturnEvent.java
@@ -1,0 +1,9 @@
+package com.github.wekaito.backend.websocket.game;
+
+import java.util.Set;
+
+public record GameLobbyReturnEvent(
+        String returningUsername,
+        Set<String> disconnectedUsernames
+) {
+}

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -30,6 +31,8 @@ public class GameWebSocket extends TextWebSocketHandler {
     private final DeckService deckService;
     
     private final CardJsonConverter cardJsonConverter;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     public final ConcurrentHashMap<String, GameRoom> gameRooms = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> roomIdBySessionId = new ConcurrentHashMap<>();
@@ -118,6 +121,16 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         if (roomMessage.equals("/returnToLobby")) {
             String username = Objects.requireNonNull(session.getPrincipal()).getName();
+            Set<String> disconnectedUsernames = Set.of(
+                            gameRoom.getPlayer1().username(),
+                            gameRoom.getPlayer2().username()
+                    ).stream()
+                    .filter(player -> !player.equals(username))
+                    .filter(player -> !gameRoom.hasOpenSessionFor(player))
+                    .collect(java.util.stream.Collectors.toSet());
+
+            eventPublisher.publishEvent(new GameLobbyReturnEvent(username, disconnectedUsernames));
+
             String returnMessage = username + " has returned to the lobby.";
             gameRoom.sendMessagesToAll("[CHAT_MESSAGE]:【SERVER】﹕" + returnMessage);
             gameRoom.sendMessageToOtherSessions(session, "[PLAYER_RETURNED_TO_LOBBY]:" + username);

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -86,6 +86,12 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         GameRoom gameRoom = findGameRoomById(gameId);
 
+        if (roomMessage.equals("/returnToLobby") &&
+                (gameRoom == null || !gameRoom.getSessions().contains(session))) {
+            session.sendMessage(new TextMessage("[RETURN_TO_LOBBY]"));
+            return;
+        }
+
         if (gameRoom == null || !gameRoom.getSessions().contains(session)) return;
 
         if(roomMessage.startsWith("/mulligan:")) {

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -33,8 +33,10 @@ public class GameWebSocket extends TextWebSocketHandler {
 
     public final ConcurrentHashMap<String, GameRoom> gameRooms = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> roomIdBySessionId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> disconnectCleanupTasks = new ConcurrentHashMap<>();
     
     private static final ScheduledExecutorService SHARED_SCHEDULER = Executors.newScheduledThreadPool(10);
+    private static final long RECONNECT_WINDOW_MINUTES = 2;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -62,6 +64,7 @@ public class GameWebSocket extends TextWebSocketHandler {
             gameRoom.removeSession(session);
             if (!gameRoom.hasOpenSessionFor(principal.getName())) {
                 gameRoom.sendMessageToOtherSessions(session, "[OPPONENT_DISCONNECTED]");
+                scheduleDisconnectCleanup(gameRoom, principal.getName());
             }
 
             // Use isEmpty method that checks for actually open sessions
@@ -111,6 +114,11 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         if (roomMessage.startsWith("/heartbeat")) {
             gameRoom.updateLastHearBeat(session);
+            return;
+        }
+
+        if (roomMessage.equals("/returnToLobby")) {
+            destroyGameRoom(gameRoom, session);
             return;
         }
 
@@ -171,6 +179,39 @@ public class GameWebSocket extends TextWebSocketHandler {
         }
         String convertedCommand = convertCommand(command);
         if (!convertedCommand.isEmpty()) gameRoom.sendMessageToOtherSessions(session, convertedCommand);
+    }
+
+    private void destroyGameRoom(GameRoom gameRoom, WebSocketSession returningSession) {
+        if (returningSession == null) gameRoom.sendMessagesToAll("[SURRENDER]");
+        else gameRoom.sendMessageToOtherSessions(returningSession, "[SURRENDER]");
+
+        if (gameRooms.remove(gameRoom.getRoomId(), gameRoom)) {
+            gameRoom.cancelAllScheduledTasks();
+        }
+        roomIdBySessionId.entrySet().removeIf(entry -> entry.getValue().equals(gameRoom.getRoomId()));
+        disconnectCleanupTasks.entrySet().removeIf(entry -> {
+            if (!entry.getKey().startsWith(gameRoom.getRoomId() + ":")) return false;
+            entry.getValue().cancel(false);
+            return true;
+        });
+    }
+
+    private void scheduleDisconnectCleanup(GameRoom gameRoom, String username) {
+        String cleanupKey = gameRoom.getRoomId() + ":" + username;
+        ScheduledFuture<?> cleanupTask = SHARED_SCHEDULER.schedule(() -> {
+            disconnectCleanupTasks.remove(cleanupKey);
+            if (gameRooms.get(gameRoom.getRoomId()) == gameRoom && !gameRoom.hasOpenSessionFor(username)) {
+                destroyGameRoom(gameRoom, null);
+            }
+        }, RECONNECT_WINDOW_MINUTES, TimeUnit.MINUTES);
+
+        ScheduledFuture<?> previousTask = disconnectCleanupTasks.put(cleanupKey, cleanupTask);
+        if (previousTask != null) previousTask.cancel(false);
+    }
+
+    private void cancelDisconnectCleanup(String gameId, String username) {
+        ScheduledFuture<?> cleanupTask = disconnectCleanupTasks.remove(gameId + ":" + username);
+        if (cleanupTask != null) cleanupTask.cancel(false);
     }
 
     private void sendChatMessage(GameRoom gameRoom, WebSocketSession session, String roomMessage) {
@@ -533,6 +574,7 @@ public class GameWebSocket extends TextWebSocketHandler {
             return;
         }
 
+        cancelDisconnectCleanup(gameId, joiningUsername);
         gameRoom.addSession(session);
         roomIdBySessionId.put(session.getId(), gameId);
 

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -63,17 +63,10 @@ public class GameWebSocket extends TextWebSocketHandler {
         if (gameRoom != null) {
             gameRoom.removeSession(session);
             if (!gameRoom.hasOpenSessionFor(principal.getName())) {
-                gameRoom.sendMessageToOtherSessions(session, "[OPPONENT_DISCONNECTED]");
-                scheduleDisconnectCleanup(gameRoom, principal.getName());
+                long reconnectDeadline = scheduleDisconnectCleanup(gameRoom, principal.getName());
+                gameRoom.sendMessageToOtherSessions(session, "[OPPONENT_DISCONNECTED]:" + reconnectDeadline);
             }
 
-            // Use isEmpty method that checks for actually open sessions
-            if (gameRoom.isEmpty()) {
-                GameRoom removed = gameRooms.remove(gameRoom.getRoomId());
-                if (removed != null) {
-                    removed.cancelAllScheduledTasks();
-                }
-            }
         }
     }
 
@@ -84,7 +77,7 @@ public class GameWebSocket extends TextWebSocketHandler {
         if (parts.length < 2) return;
 
         if (parts[0].equals("/joinGame")) {
-            computeGameRoom(session, parts[1]);
+            joinGameRoom(session, parts[1]);
             return;
         }
 
@@ -207,8 +200,9 @@ public class GameWebSocket extends TextWebSocketHandler {
         });
     }
 
-    private void scheduleDisconnectCleanup(GameRoom gameRoom, String username) {
+    private long scheduleDisconnectCleanup(GameRoom gameRoom, String username) {
         String cleanupKey = gameRoom.getRoomId() + ":" + username;
+        long reconnectDeadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(RECONNECT_WINDOW_MINUTES);
         ScheduledFuture<?> cleanupTask = SHARED_SCHEDULER.schedule(() -> {
             disconnectCleanupTasks.remove(cleanupKey);
             if (gameRooms.get(gameRoom.getRoomId()) == gameRoom && !gameRoom.hasOpenSessionFor(username)) {
@@ -218,6 +212,7 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         ScheduledFuture<?> previousTask = disconnectCleanupTasks.put(cleanupKey, cleanupTask);
         if (previousTask != null) previousTask.cancel(false);
+        return reconnectDeadline;
     }
 
     private void cancelDisconnectCleanup(String gameId, String username) {
@@ -526,68 +521,72 @@ public class GameWebSocket extends TextWebSocketHandler {
                toServer.equals("player1Trash") || toServer.equals("player2Trash");
     }
 
-    private void computeGameRoom(WebSocketSession session, String gameId) throws IOException {
-        GameRoom gameRoom = gameRooms.get(gameId);
-        boolean shouldStartScheduledTasks = false;
-
-        if (gameRoom == null) {
-            String[] usernames = gameId.split("‗");
-            String joiningUsername = session.getPrincipal() == null ? null : session.getPrincipal().getName();
-            if (usernames.length != 2 || joiningUsername == null || Arrays.stream(usernames).noneMatch(joiningUsername::equals)) {
-                return;
-            }
-
-            try {
-                String avatar1 = mongoUserDetailsService.getAvatar(usernames[0]);
-                String avatar2 = mongoUserDetailsService.getAvatar(usernames[1]);
-
-                String deckId1 = mongoUserDetailsService.getActiveDeck(usernames[0]);
-                String deckId2 = mongoUserDetailsService.getActiveDeck(usernames[1]);
-
-                String mainSleeve1 = deckService.getDeckSleeveById(deckId1);
-                String mainSleeve2 = deckService.getDeckSleeveById(deckId2);
-
-                String eggSleeve1 = deckService.getEggDeckSleeveById(deckId1);
-                String eggSleeve2 = deckService.getEggDeckSleeveById(deckId2);
-
-                Player player1 = new Player(usernames[0], avatar1, mainSleeve1, eggSleeve1);
-                Player player2 = new Player(usernames[1], avatar2, mainSleeve2, eggSleeve2);
-
-                List<Card> player1MainDeck = deckService.getMainDeckCardsById(deckId1);
-                List<Card> player1EggDeck = deckService.getEggDeckCardsById(deckId1);
-
-                List<Card> player2MainDeck = deckService.getMainDeckCardsById(deckId2);
-                List<Card> player2EggDeck = deckService.getEggDeckCardsById(deckId2);
-
-                GameRoom newGameRoom = new GameRoom(gameId, player1, player1MainDeck, player1EggDeck, player2, player2MainDeck, player2EggDeck);
-                newGameRoom.setChat(new String[0]);
-
-                GameRoom existingRoom = gameRooms.putIfAbsent(gameId, newGameRoom);
-                if (existingRoom == null) {
-                    gameRoom = newGameRoom;
-                    shouldStartScheduledTasks = true;
-                } else {
-                    gameRoom = existingRoom; // Another thread created it first
-                }
-            } catch (Exception e) {
-                return;
-            }
+    public boolean createGameRoom(String gameId, String username1, String username2) {
+        if (gameId == null || gameId.isBlank() || username1 == null || username2 == null || username1.equals(username2)) {
+            return false;
         }
 
-        if (shouldStartScheduledTasks) {
+        try {
+            String avatar1 = mongoUserDetailsService.getAvatar(username1);
+            String avatar2 = mongoUserDetailsService.getAvatar(username2);
+
+            String deckId1 = mongoUserDetailsService.getActiveDeck(username1);
+            String deckId2 = mongoUserDetailsService.getActiveDeck(username2);
+
+            String mainSleeve1 = deckService.getDeckSleeveById(deckId1);
+            String mainSleeve2 = deckService.getDeckSleeveById(deckId2);
+
+            String eggSleeve1 = deckService.getEggDeckSleeveById(deckId1);
+            String eggSleeve2 = deckService.getEggDeckSleeveById(deckId2);
+
+            Player player1 = new Player(username1, avatar1, mainSleeve1, eggSleeve1);
+            Player player2 = new Player(username2, avatar2, mainSleeve2, eggSleeve2);
+
+            List<Card> player1MainDeck = deckService.getMainDeckCardsById(deckId1);
+            List<Card> player1EggDeck = deckService.getEggDeckCardsById(deckId1);
+
+            List<Card> player2MainDeck = deckService.getMainDeckCardsById(deckId2);
+            List<Card> player2EggDeck = deckService.getEggDeckCardsById(deckId2);
+
+            GameRoom gameRoom = new GameRoom(
+                    gameId,
+                    player1,
+                    player1MainDeck,
+                    player1EggDeck,
+                    player2,
+                    player2MainDeck,
+                    player2EggDeck
+            );
+            gameRoom.setChat(new String[0]);
+
+            if (gameRooms.putIfAbsent(gameId, gameRoom) != null) return false;
             startGameRoomScheduledTasks(gameRoom);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Unable to create game room " + gameId + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    private void joinGameRoom(WebSocketSession session, String gameId) throws IOException {
+        GameRoom gameRoom = gameRooms.get(gameId);
+        if (gameRoom == null) {
+            session.sendMessage(new TextMessage("[GAME_JOIN_REJECTED]"));
+            return;
         }
 
         String joiningUsername = session.getPrincipal() == null ? null : session.getPrincipal().getName();
         if (joiningUsername == null ||
                 (!gameRoom.getPlayer1().username().equals(joiningUsername) &&
                  !gameRoom.getPlayer2().username().equals(joiningUsername))) {
+            session.sendMessage(new TextMessage("[GAME_JOIN_REJECTED]"));
             return;
         }
 
         cancelDisconnectCleanup(gameId, joiningUsername);
         gameRoom.addSession(session);
         roomIdBySessionId.put(session.getId(), gameId);
+        session.sendMessage(new TextMessage("[GAME_JOINED]"));
 
         GameRoom gameRoomFromMap = gameRooms.get(gameId); // Retrieve again to ensure consistency
 
@@ -991,7 +990,9 @@ public class GameWebSocket extends TextWebSocketHandler {
                 return; // Early exit if room no longer exists
             }
             try {
-                if (gameRoom.isEmpty()) {
+                boolean reconnectPending = disconnectCleanupTasks.keySet().stream()
+                        .anyMatch(key -> key.startsWith(gameRoom.getRoomId() + ":"));
+                if (gameRoom.isEmpty() && !reconnectPending) {
                     GameRoom removed = gameRooms.remove(gameRoom.getRoomId());
                     if (removed != null) {
                         removed.cancelAllScheduledTasks();

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -180,7 +180,9 @@ public class GameWebSocket extends TextWebSocketHandler {
         if (command.equals("/updatePhase")) {
             synchronized (gameRoom.getMutationLock()) {
                 gameRoom.progressPhase();
+                broadcastAuthoritativeBoardState(gameRoom);
             }
+            return;
         }
         String convertedCommand = convertCommand(command);
         if (!convertedCommand.isEmpty()) gameRoom.sendMessageToOtherSessions(session, convertedCommand);
@@ -684,9 +686,26 @@ public class GameWebSocket extends TextWebSocketHandler {
         // Add memory values
         completeBoardState.put("player1Memory", boardState.getPlayer1Memory());
         completeBoardState.put("player2Memory", boardState.getPlayer2Memory());
+        completeBoardState.put("phase", gameRoom.getPhase());
+        completeBoardState.put("usernameTurn", gameRoom.getUsernameTurn());
+        completeBoardState.put("bootStage", gameRoom.getBootStage());
 
         String boardStateJson = objectMapper.writeValueAsString(completeBoardState);
         gameRoom.sendMessage(session, "[BOARD_STATE]:" + boardStateJson);
+    }
+
+    private void broadcastAuthoritativeBoardState(GameRoom gameRoom) {
+        BoardState boardState = gameRoom.getBoardState();
+        if (boardState == null) return;
+
+        for (WebSocketSession connectedSession : gameRoom.getSessions()) {
+            if (!connectedSession.isOpen()) continue;
+            try {
+                distributeBoardStateCards(gameRoom, boardState, connectedSession);
+            } catch (IOException e) {
+                System.err.println("Failed to broadcast board state for room " + gameRoom.getRoomId() + ": " + e.getMessage());
+            }
+        }
     }
 
     private void handleAttack(GameRoom gameRoom, WebSocketSession session, String message) {
@@ -717,8 +736,7 @@ public class GameWebSocket extends TextWebSocketHandler {
                 return;
             }
 
-            gameRoom.sendMessageToOtherSessions(session, "[MOVE_CARD]:" + cardId + ":" + getOppositePosition(from) + ":" + getOppositePosition(to));
-            gameRoom.sendMessage(session, "[MOVE_CARD_CONFIRMED]:" + cardId + ":" + from + ":" + to);
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
 
@@ -731,7 +749,7 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         synchronized (gameRoom.getMutationLock()) {
             updateCardModifiers(session, gameRoom, cardId, location, modifiersJson);
-            gameRoom.sendMessageToOtherSessions(session, "[SET_MODIFIERS]:" + cardId + ":" + getOppositePosition(location) + ":" + modifiersJson);
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
 
@@ -756,8 +774,7 @@ public class GameWebSocket extends TextWebSocketHandler {
                 return;
             }
 
-            gameRoom.sendMessageToOtherSessions(session, "[MOVE_CARD_TO_STACK]:" + topOrBottom + ":" + cardId + ":" + getOppositePosition(from) + ":" + getOppositePosition(to) + ":" + facing);
-            gameRoom.sendMessage(session, "[MOVE_CARD_TO_STACK_CONFIRMED]:" + topOrBottom + ":" + cardId + ":" + from + ":" + to + ":" + facing);
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
 
@@ -778,7 +795,7 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         synchronized (gameRoom.getMutationLock()) {
             updateCardTiltStatus(session, gameRoom, cardId, location);
-            gameRoom.sendMessageToOtherSessions(session, "[TILT_CARD]:" + cardId + ":" + getOppositePosition(location));
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
 
@@ -790,7 +807,7 @@ public class GameWebSocket extends TextWebSocketHandler {
 
         synchronized (gameRoom.getMutationLock()) {
             updateCardFaceStatus(session, gameRoom, cardId, location);
-            gameRoom.sendMessageToOtherSessions(session, "[FLIP_CARD]:" + cardId + ":" + getOppositePosition(location));
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
 
@@ -843,7 +860,7 @@ public class GameWebSocket extends TextWebSocketHandler {
     private void handleUnsuspendAll(GameRoom gameRoom, WebSocketSession session) {
         synchronized (gameRoom.getMutationLock()) {
             unsuspendAllCardsInBoardState(gameRoom, session);
-            gameRoom.sendMessageToOtherSessions(session, "[UNSUSPEND_ALL]");
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
     
@@ -903,8 +920,7 @@ public class GameWebSocket extends TextWebSocketHandler {
                     currentList.add(card);
                     boardState.setFieldByName(serverPosition, currentList);
 
-                    gameRoom.sendMessageToOtherSessions(session,
-                        "[CREATE_TOKEN]:" + card.getId() + ":" + card.getName() + ":" + getOppositePosition(targetPosition));
+                    broadcastAuthoritativeBoardState(gameRoom);
                 }
                     
             } catch (Exception e) {
@@ -935,7 +951,7 @@ public class GameWebSocket extends TextWebSocketHandler {
                     boardState.setPlayer2Memory(newMemory);
                 }
             }
-            gameRoom.sendMessageToOtherSessions(session, "[UPDATE_MEMORY]:" + memory);
+            broadcastAuthoritativeBoardState(gameRoom);
         }
     }
     }

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -119,6 +119,11 @@ public class GameWebSocket extends TextWebSocketHandler {
             return;
         }
 
+        if (roomMessage.equals("/surrender")) {
+            destroyGameRoom(gameRoom, session);
+            return;
+        }
+
         if (roomMessage.equals("/returnToLobby")) {
             String username = Objects.requireNonNull(session.getPrincipal()).getName();
             Set<String> disconnectedUsernames = Set.of(
@@ -312,6 +317,13 @@ public class GameWebSocket extends TextWebSocketHandler {
         return gameRooms.values().stream().filter(room ->
                 room.getPlayer1().username().equals(username) || room.getPlayer2().username().equals(username)
         ).findFirst();
+    }
+
+    public Optional<GameRoom> findReconnectableGameRoomBySession(WebSocketSession session) {
+        String username = Objects.requireNonNull(session.getPrincipal()).getName();
+        return findGameRoomBySession(session).filter(room ->
+                disconnectCleanupTasks.containsKey(room.getRoomId() + ":" + username)
+        );
     }
     
     private String mapClientToServer(String clientPosition, String username, GameRoom gameRoom) {

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -118,7 +118,12 @@ public class GameWebSocket extends TextWebSocketHandler {
         }
 
         if (roomMessage.equals("/returnToLobby")) {
-            destroyGameRoom(gameRoom, session);
+            String username = Objects.requireNonNull(session.getPrincipal()).getName();
+            String returnMessage = username + " has returned to the lobby.";
+            gameRoom.sendMessagesToAll("[CHAT_MESSAGE]:【SERVER】﹕" + returnMessage);
+            gameRoom.sendMessageToOtherSessions(session, "[PLAYER_RETURNED_TO_LOBBY]:" + username);
+            gameRoom.sendMessage(session, "[RETURN_TO_LOBBY]");
+            removeGameRoom(gameRoom);
             return;
         }
 
@@ -185,6 +190,10 @@ public class GameWebSocket extends TextWebSocketHandler {
         if (returningSession == null) gameRoom.sendMessagesToAll("[SURRENDER]");
         else gameRoom.sendMessageToOtherSessions(returningSession, "[SURRENDER]");
 
+        removeGameRoom(gameRoom);
+    }
+
+    private void removeGameRoom(GameRoom gameRoom) {
         if (gameRooms.remove(gameRoom.getRoomId(), gameRoom)) {
             gameRoom.cancelAllScheduledTasks();
         }

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -45,6 +45,8 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     private final Map<String, Long> emptyRoomTimestamps = new ConcurrentHashMap<>();
     private final Map<WebSocketSession, String> lastPlayerRooms = new ConcurrentHashMap<>(); // username -> roomId
+    private final Map<String, String> gameLobbyRoomByUsername = new ConcurrentHashMap<>();
+    private final Set<String> roomsWithActiveGames = ConcurrentHashMap.newKeySet();
 
     private final Object quickPlayLock = new Object();
 
@@ -83,7 +85,10 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         }
 
         globalActiveSessions.removeIf(s -> Objects.equals(Objects.requireNonNull(s.getPrincipal()).getName(), username));
-        if (tryReconnectToRoom(session)) return; // Try to reconnect first
+        if (tryReconnectToRoom(session)) {
+            globalActiveSessions.add(session);
+            return;
+        }
 
         List<String> userBlockedAccounts = mongoUserDetailsService.getBlockedAccounts(username);
 
@@ -112,6 +117,13 @@ public class LobbyWebSocket extends TextWebSocketHandler {
                     .orElse(null);
 
             if (playerRoom != null) {
+                if (roomsWithActiveGames.contains(playerRoom.getId())) {
+                    lastHeartbeatTimestamps.remove(session);
+                    quickPlayQueue.remove(session);
+                    globalActiveSessions.remove(session);
+                    return;
+                }
+
                 synchronized (playerRoom) {
                     // Store which room the player was in for potential reconnect
                     lastPlayerRooms.put(session, playerRoom.getId());
@@ -239,6 +251,23 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     private boolean tryReconnectToRoom(WebSocketSession session) throws IOException {
         String username = Objects.requireNonNull(session.getPrincipal()).getName();
 
+        String gameLobbyRoomId = gameLobbyRoomByUsername.get(username);
+        if (gameLobbyRoomId != null) {
+            Room gameLobbyRoom = getRoomById(gameLobbyRoomId);
+            if (gameLobbyRoom != null) {
+                synchronized (gameLobbyRoom) {
+                    gameLobbyRoom.getPlayers().removeIf(player -> player.getName().equals(username));
+                    boolean isHost = gameLobbyRoom.getHostName().equals(username);
+                    gameLobbyRoom.getPlayers().add(new LobbyPlayer(session, username, isHost));
+                }
+                roomsWithActiveGames.remove(gameLobbyRoomId);
+                sendTextMessage(session, "[JOIN_ROOM]:" + objectMapper.writeValueAsString(getRoomDTO(gameLobbyRoom)));
+                sendRoomUpdate(gameLobbyRoom);
+                return true;
+            }
+            gameLobbyRoomByUsername.remove(username, gameLobbyRoomId);
+        }
+
         // Check if player was previously in a room using lastPlayerRooms map
         String previousRoomId = lastPlayerRooms.get(session);
         if (previousRoomId != null) {
@@ -281,11 +310,12 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         if (room == null) return;
 
         for (LobbyPlayer player : room.getPlayers()) {
-            sendTextMessage(player.getSession(), "[COMPUTE_GAME]:" + gameId);
+            gameLobbyRoomByUsername.put(player.getName(), roomId);
+            sendTextMessage(player.getSession(), "[COMPUTE_ROOM_GAME]:" + gameId + ":" + roomId);
             lastPlayerRooms.remove(player.getSession());
         }
 
-        rooms.remove(room);
+        roomsWithActiveGames.add(roomId);
     }
 
     @Scheduled(fixedRate = 5000) // 5 seconds
@@ -601,6 +631,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         if (shouldCleanLastRoom.equals("false")) return;
 
         lastPlayerRooms.remove(session);
+        gameLobbyRoomByUsername.remove(userName);
 
         Room room = getRoomById(roomId);
         if (room == null) {
@@ -677,6 +708,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
             room.getPlayers().remove(player);
             lastPlayerRooms.remove(session);
+            gameLobbyRoomByUsername.remove(userName);
         }
 
         sendRoomUpdate(room);

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -7,10 +7,12 @@ import com.github.wekaito.backend.CardService;
 import com.github.wekaito.backend.DeckService;
 import com.github.wekaito.backend.security.MongoUserDetailsService;
 import com.github.wekaito.backend.websocket.game.GameWebSocket;
+import com.github.wekaito.backend.websocket.game.GameLobbyReturnEvent;
 import com.github.wekaito.backend.websocket.game.models.GameRoom;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -253,6 +255,25 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     private record PendingGameInvite(String inviter, String invitedPlayer) {}
 
+    @EventListener
+    public void handleGameLobbyReturn(GameLobbyReturnEvent event) {
+        String roomId = gameLobbyRoomByUsername.get(event.returningUsername());
+        Room room = roomId == null ? null : getRoomById(roomId);
+        if (room == null || !room.getHostName().equals(event.returningUsername())) return;
+
+        synchronized (room) {
+            room.getPlayers().removeIf(player -> event.disconnectedUsernames().contains(player.getName()));
+            event.disconnectedUsernames().forEach(username -> gameLobbyRoomByUsername.remove(username, roomId));
+        }
+
+        roomsWithActiveGames.remove(roomId);
+        try {
+            sendRoomUpdate(room);
+        } catch (IOException e) {
+            System.err.println("Unable to broadcast lobby cleanup for room " + roomId + ": " + e.getMessage());
+        }
+    }
+
     private boolean tryReconnectToRoom(WebSocketSession session) throws IOException {
         String username = Objects.requireNonNull(session.getPrincipal()).getName();
 
@@ -260,12 +281,27 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         if (gameLobbyRoomId != null) {
             Room gameLobbyRoom = getRoomById(gameLobbyRoomId);
             if (gameLobbyRoom != null) {
+                boolean gameIsActive = gameWebSocket.findGameRoomBySession(session).isPresent();
+                boolean returningPlayerIsHost = gameLobbyRoom.getHostName().equals(username);
+
                 synchronized (gameLobbyRoom) {
                     gameLobbyRoom.getPlayers().removeIf(player -> player.getName().equals(username));
-                    boolean isHost = gameLobbyRoom.getHostName().equals(username);
-                    gameLobbyRoom.getPlayers().add(new LobbyPlayer(session, username, isHost));
+                    gameLobbyRoom.getPlayers().add(new LobbyPlayer(session, username, returningPlayerIsHost));
+
+                    if (returningPlayerIsHost && !gameIsActive) {
+                        List<LobbyPlayer> disconnectedPlayers = gameLobbyRoom.getPlayers().stream()
+                                .filter(player -> !player.getName().equals(username))
+                                .filter(player -> !player.getSession().isOpen())
+                                .toList();
+
+                        gameLobbyRoom.getPlayers().removeAll(disconnectedPlayers);
+                        disconnectedPlayers.forEach(player -> {
+                            gameLobbyRoomByUsername.remove(player.getName(), gameLobbyRoomId);
+                            lastPlayerRooms.remove(player.getSession());
+                        });
+                    }
                 }
-                if (gameWebSocket.findGameRoomBySession(session).isPresent()) {
+                if (gameIsActive) {
                     roomsWithActiveGames.add(gameLobbyRoomId);
                 } else {
                     roomsWithActiveGames.remove(gameLobbyRoomId);

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -10,7 +10,6 @@ import com.github.wekaito.backend.websocket.game.GameWebSocket;
 import com.github.wekaito.backend.websocket.game.models.GameRoom;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
@@ -54,8 +53,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     public final LinkedList<ChatMessage> globalChatMessages = new LinkedList<>(List.of(new ChatMessage("Join our Discord!", "【SERVER】")));
 
-    @Autowired
-    private GameWebSocket gameWebSocket;
+    private final GameWebSocket gameWebSocket;
 
     private void sendTextMessage(WebSocketSession session, String message) throws IOException {
         if (session == null || !session.isOpen()) return;
@@ -174,7 +172,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (payload.startsWith("/cancelQuickPlay")) quickPlayQueue.remove(session); // manage representation in Frontend
 
-        if (payload.startsWith("/startGame:")) startGame(payload);
+        if (payload.startsWith("/startGame:")) startGame(session, payload);
 
         if (payload.startsWith("/chatMessage:")) handleChatMessage(session, payload);
 
@@ -241,6 +239,11 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
         if (accepted) {
             String gameId = inviter + "‗" + invitedPlayer;
+            if (!gameWebSocket.createGameRoom(gameId, inviter, invitedPlayer)) {
+                sendTextMessage(inviterSession, "[CHAT_MESSAGE]:【SERVER】: Unable to create the game.");
+                sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: Unable to create the game.");
+                return;
+            }
             sendTextMessage(inviterSession, "[COMPUTE_GAME]:" + gameId);
             sendTextMessage(session, "[COMPUTE_GAME]:" + gameId);
             lastPlayerRooms.remove(inviterSession);
@@ -307,13 +310,25 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         return false; // No reconnection happened
     }
 
-    private void startGame(String payload) throws IOException {
+    private void startGame(WebSocketSession session, String payload) throws IOException {
         String[] parts = payload.split(":", 3);
+        if (parts.length < 3 || session.getPrincipal() == null) return;
+
         String roomId = parts[1];
-        String gameId = parts[2];
 
         Room room = getRoomById(roomId);
-        if (room == null) return;
+        if (room == null || room.getPlayers().size() != 2) return;
+        if (!room.getHostName().equals(session.getPrincipal().getName())) return;
+
+        List<String> usernames = room.getPlayers().stream().map(LobbyPlayer::getName).toList();
+        String requestedGameId = parts[2];
+        String gameId = usernames.get(0) + "‗" + usernames.get(1);
+        boolean requestedPlayersMatch = new HashSet<>(Arrays.asList(requestedGameId.split("‗")))
+                .equals(new HashSet<>(usernames));
+        if (!requestedPlayersMatch || !gameWebSocket.createGameRoom(gameId, usernames.get(0), usernames.get(1))) {
+            sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: Unable to create the game.");
+            return;
+        }
 
         for (LobbyPlayer player : room.getPlayers()) {
             gameLobbyRoomByUsername.put(player.getName(), roomId);
@@ -399,6 +414,10 @@ public class LobbyWebSocket extends TextWebSocketHandler {
             }
 
             String newGameId = username1 + "‗" + username2;
+
+            if (!gameWebSocket.createGameRoom(newGameId, username1, username2)) {
+                continue;
+            }
 
             quickPlayQueue.remove(p1);
             quickPlayQueue.remove(p2);

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -87,6 +87,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         globalActiveSessions.removeIf(s -> Objects.equals(Objects.requireNonNull(s.getPrincipal()).getName(), username));
         if (tryReconnectToRoom(session)) {
             globalActiveSessions.add(session);
+            sendReconnectStatus(session);
             return;
         }
 
@@ -103,6 +104,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
 
         globalActiveSessions.add(session);
+        sendReconnectStatus(session);
     }
 
     @Override
@@ -260,7 +262,11 @@ public class LobbyWebSocket extends TextWebSocketHandler {
                     boolean isHost = gameLobbyRoom.getHostName().equals(username);
                     gameLobbyRoom.getPlayers().add(new LobbyPlayer(session, username, isHost));
                 }
-                roomsWithActiveGames.remove(gameLobbyRoomId);
+                if (gameWebSocket.findGameRoomBySession(session).isPresent()) {
+                    roomsWithActiveGames.add(gameLobbyRoomId);
+                } else {
+                    roomsWithActiveGames.remove(gameLobbyRoomId);
+                }
                 sendTextMessage(session, "[JOIN_ROOM]:" + objectMapper.writeValueAsString(getRoomDTO(gameLobbyRoom)));
                 sendRoomUpdate(gameLobbyRoom);
                 return true;
@@ -499,10 +505,14 @@ public class LobbyWebSocket extends TextWebSocketHandler {
 
     private void checkForRejoinableGameRoom() throws IOException {
         for (WebSocketSession session : globalActiveSessions) {
-            Optional<GameRoom> room = gameWebSocket.findGameRoomBySession(session);
-            if (room.isPresent()) sendTextMessage(session, "[RECONNECT_ENABLED]:" + room.get().getRoomId());
-            else sendTextMessage(session, "[RECONNECT_DISABLED]");
+            sendReconnectStatus(session);
         }
+    }
+
+    private void sendReconnectStatus(WebSocketSession session) throws IOException {
+        Optional<GameRoom> room = gameWebSocket.findGameRoomBySession(session);
+        if (room.isPresent()) sendTextMessage(session, "[RECONNECT_ENABLED]:" + room.get().getRoomId());
+        else sendTextMessage(session, "[RECONNECT_DISABLED]");
     }
 
     private int getTotalSessionCount() {

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -565,7 +565,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
     }
 
     private void sendReconnectStatus(WebSocketSession session) throws IOException {
-        Optional<GameRoom> room = gameWebSocket.findGameRoomBySession(session);
+        Optional<GameRoom> room = gameWebSocket.findReconnectableGameRoomBySession(session);
         if (room.isPresent()) sendTextMessage(session, "[RECONNECT_ENABLED]:" + room.get().getRoomId());
         else sendTextMessage(session, "[RECONNECT_DISABLED]");
     }

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
@@ -17,7 +17,7 @@ class GameWebSocketJoinTest {
 
     @Test
     void joiningMissingGameIsRejectedWithoutCreatingRoom() throws Exception {
-        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, event -> {});
         List<String> messages = new ArrayList<>();
         WebSocketSession session = createSession("player", messages);
 
@@ -29,7 +29,7 @@ class GameWebSocketJoinTest {
 
     @Test
     void returningFromMissingGameStillAcknowledgesLobbyNavigation() throws Exception {
-        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, event -> {});
         List<String> messages = new ArrayList<>();
         WebSocketSession session = createSession("player", messages);
 

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
@@ -1,5 +1,7 @@
 package com.github.wekaito.backend.websocket.game;
 
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
@@ -38,6 +40,32 @@ class GameWebSocketJoinTest {
         assertEquals(List.of("[RETURN_TO_LOBBY]"), messages);
     }
 
+    @Test
+    void surrenderDestroysGameAndNotifiesOpponent() throws Exception {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, event -> {});
+        List<String> surrenderingPlayerMessages = new ArrayList<>();
+        List<String> opponentMessages = new ArrayList<>();
+        WebSocketSession surrenderingPlayer = createSession("player", surrenderingPlayerMessages);
+        WebSocketSession opponent = createSession("opponent", opponentMessages);
+        GameRoom room = new GameRoom(
+                "game",
+                new Player("player", "", "", ""),
+                List.of(),
+                List.of(),
+                new Player("opponent", "", "", ""),
+                List.of(),
+                List.of()
+        );
+        room.addSession(surrenderingPlayer);
+        room.addSession(opponent);
+        gameWebSocket.getGameRooms().put("game", room);
+
+        gameWebSocket.handleTextMessage(surrenderingPlayer, new TextMessage("game:/surrender"));
+
+        assertTrue(gameWebSocket.getGameRooms().isEmpty());
+        assertEquals(List.of("[SURRENDER]"), opponentMessages);
+    }
+
     private WebSocketSession createSession(String username, List<String> messages) {
         Principal principal = () -> username;
         return (WebSocketSession) Proxy.newProxyInstance(
@@ -45,6 +73,7 @@ class GameWebSocketJoinTest {
                 new Class<?>[]{WebSocketSession.class},
                 (proxy, method, args) -> switch (method.getName()) {
                     case "getPrincipal" -> principal;
+                    case "getId" -> username + "-session";
                     case "isOpen" -> true;
                     case "sendMessage" -> {
                         WebSocketMessage<?> message = (WebSocketMessage<?>) args[0];

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
@@ -27,6 +27,17 @@ class GameWebSocketJoinTest {
         assertEquals(List.of("[GAME_JOIN_REJECTED]"), messages);
     }
 
+    @Test
+    void returningFromMissingGameStillAcknowledgesLobbyNavigation() throws Exception {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        List<String> messages = new ArrayList<>();
+        WebSocketSession session = createSession("player", messages);
+
+        gameWebSocket.handleTextMessage(session, new TextMessage("expired-game:/returnToLobby"));
+
+        assertEquals(List.of("[RETURN_TO_LOBBY]"), messages);
+    }
+
     private WebSocketSession createSession(String username, List<String> messages) {
         Principal principal = () -> username;
         return (WebSocketSession) Proxy.newProxyInstance(

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketJoinTest.java
@@ -1,0 +1,49 @@
+package com.github.wekaito.backend.websocket.game;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Proxy;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GameWebSocketJoinTest {
+
+    @Test
+    void joiningMissingGameIsRejectedWithoutCreatingRoom() throws Exception {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null);
+        List<String> messages = new ArrayList<>();
+        WebSocketSession session = createSession("player", messages);
+
+        gameWebSocket.handleTextMessage(session, new TextMessage("/joinGame:player‗opponent"));
+
+        assertTrue(gameWebSocket.getGameRooms().isEmpty());
+        assertEquals(List.of("[GAME_JOIN_REJECTED]"), messages);
+    }
+
+    private WebSocketSession createSession(String username, List<String> messages) {
+        Principal principal = () -> username;
+        return (WebSocketSession) Proxy.newProxyInstance(
+                WebSocketSession.class.getClassLoader(),
+                new Class<?>[]{WebSocketSession.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getPrincipal" -> principal;
+                    case "isOpen" -> true;
+                    case "sendMessage" -> {
+                        WebSocketMessage<?> message = (WebSocketMessage<?>) args[0];
+                        messages.add(message.getPayload().toString());
+                        yield null;
+                    }
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> null;
+                }
+        );
+    }
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
@@ -1,0 +1,82 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Proxy;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LobbyRoomReturnTest {
+
+    @Test
+    void roomCreatedMatchPreservesRoomAndMarksBothPlayersForReturn() throws Exception {
+        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(null, null, null);
+        TestSession host = new TestSession("host");
+        TestSession guest = new TestSession("guest");
+        Room room = new Room(
+                "room-id",
+                "Rematch Room",
+                "host",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(host.session(), "host", true),
+                        new LobbyPlayer(guest.session(), "guest", true)
+                ))
+        );
+        lobbyWebSocket.getRooms().add(room);
+
+        lobbyWebSocket.handleTextMessage(
+                host.session(),
+                new TextMessage("/startGame:room-id:host‗guest")
+        );
+
+        assertTrue(lobbyWebSocket.getRooms().contains(room));
+        assertTrue(lobbyWebSocket.getRoomsWithActiveGames().contains("room-id"));
+        assertEquals("room-id", lobbyWebSocket.getGameLobbyRoomByUsername().get("host"));
+        assertEquals("room-id", lobbyWebSocket.getGameLobbyRoomByUsername().get("guest"));
+        assertTrue(host.messages().contains("[COMPUTE_ROOM_GAME]:host‗guest:room-id"));
+        assertTrue(guest.messages().contains("[COMPUTE_ROOM_GAME]:host‗guest:room-id"));
+    }
+
+    private record TestSession(WebSocketSession session, List<String> messages) {
+        TestSession(String username) {
+            this(createFixture(username));
+        }
+
+        private TestSession(SessionFixture fixture) {
+            this(fixture.session(), fixture.messages());
+        }
+
+        private static SessionFixture createFixture(String username) {
+            List<String> messages = new ArrayList<>();
+            Principal principal = () -> username;
+            WebSocketSession session = (WebSocketSession) Proxy.newProxyInstance(
+                    WebSocketSession.class.getClassLoader(),
+                    new Class<?>[]{WebSocketSession.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "getPrincipal" -> principal;
+                        case "isOpen" -> true;
+                        case "sendMessage" -> {
+                            WebSocketMessage<?> message = (WebSocketMessage<?>) args[0];
+                            messages.add(message.getPayload().toString());
+                            yield null;
+                        }
+                        case "hashCode" -> System.identityHashCode(proxy);
+                        case "equals" -> proxy == args[0];
+                        default -> null;
+                    }
+            );
+            return new SessionFixture(session, messages);
+        }
+    }
+
+    private record SessionFixture(WebSocketSession session, List<String> messages) {}
+}

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
@@ -1,6 +1,8 @@
 package com.github.wekaito.backend.websocket.lobby;
 
+import com.github.wekaito.backend.security.MongoUserDetailsService;
 import com.github.wekaito.backend.websocket.game.GameWebSocket;
+import com.github.wekaito.backend.websocket.game.GameLobbyReturnEvent;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
@@ -10,6 +12,7 @@ import java.lang.reflect.Proxy;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,13 +21,19 @@ class LobbyRoomReturnTest {
 
     @Test
     void roomCreatedMatchPreservesRoomAndMarksBothPlayersForReturn() throws Exception {
-        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null) {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, event -> {}) {
             @Override
             public boolean createGameRoom(String gameId, String username1, String username2) {
                 return true;
             }
         };
-        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(null, null, null, gameWebSocket);
+        MongoUserDetailsService userDetailsService = new MongoUserDetailsService(null, null) {
+            @Override
+            public String getAvatar(String username) {
+                return "avatar";
+            }
+        };
+        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(userDetailsService, null, null, gameWebSocket);
         TestSession host = new TestSession("host");
         TestSession guest = new TestSession("guest");
         Room room = new Room(
@@ -53,16 +62,56 @@ class LobbyRoomReturnTest {
         assertTrue(guest.messages().contains("[COMPUTE_ROOM_GAME]:host‗guest:room-id"));
     }
 
+    @Test
+    void hostReturnEventRemovesGuestEvenWhenStaleLobbySocketLooksOpen() {
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null, event -> {});
+        MongoUserDetailsService userDetailsService = new MongoUserDetailsService(null, null) {
+            @Override
+            public String getAvatar(String username) {
+                return "avatar";
+            }
+        };
+        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(userDetailsService, null, null, gameWebSocket);
+        TestSession oldHost = new TestSession("host", false);
+        TestSession disconnectedGuestWithStaleLobbySocket = new TestSession("guest", true);
+        Room room = new Room(
+                "room-id",
+                "Rematch Room",
+                "host",
+                false,
+                "",
+                new ArrayList<>(List.of(
+                        new LobbyPlayer(oldHost.session(), "host", true),
+                        new LobbyPlayer(disconnectedGuestWithStaleLobbySocket.session(), "guest", true)
+                ))
+        );
+        lobbyWebSocket.getRooms().add(room);
+        lobbyWebSocket.getRoomsWithActiveGames().add("room-id");
+        lobbyWebSocket.getGameLobbyRoomByUsername().put("host", "room-id");
+        lobbyWebSocket.getGameLobbyRoomByUsername().put("guest", "room-id");
+
+        lobbyWebSocket.handleGameLobbyReturn(new GameLobbyReturnEvent("host", Set.of("guest")));
+
+        assertEquals(List.of("host"), room.getPlayers().stream().map(LobbyPlayer::getName).toList());
+        assertTrue(room.getPlayers().get(0).isReady());
+        assertEquals(null, lobbyWebSocket.getGameLobbyRoomByUsername().get("guest"));
+        assertTrue(!lobbyWebSocket.getRoomsWithActiveGames().contains("room-id"));
+    }
+
     private record TestSession(WebSocketSession session, List<String> messages) {
         TestSession(String username) {
-            this(createFixture(username));
+            this(username, true);
+        }
+
+        TestSession(String username, boolean open) {
+            this(createFixture(username, open));
         }
 
         private TestSession(SessionFixture fixture) {
             this(fixture.session(), fixture.messages());
         }
 
-        private static SessionFixture createFixture(String username) {
+        private static SessionFixture createFixture(String username, boolean open) {
             List<String> messages = new ArrayList<>();
             Principal principal = () -> username;
             WebSocketSession session = (WebSocketSession) Proxy.newProxyInstance(
@@ -70,7 +119,7 @@ class LobbyRoomReturnTest {
                     new Class<?>[]{WebSocketSession.class},
                     (proxy, method, args) -> switch (method.getName()) {
                         case "getPrincipal" -> principal;
-                        case "isOpen" -> true;
+                        case "isOpen" -> open;
                         case "sendMessage" -> {
                             WebSocketMessage<?> message = (WebSocketMessage<?>) args[0];
                             messages.add(message.getPayload().toString());

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyRoomReturnTest.java
@@ -1,5 +1,6 @@
 package com.github.wekaito.backend.websocket.lobby;
 
+import com.github.wekaito.backend.websocket.game.GameWebSocket;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
@@ -17,7 +18,13 @@ class LobbyRoomReturnTest {
 
     @Test
     void roomCreatedMatchPreservesRoomAndMarksBothPlayersForReturn() throws Exception {
-        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(null, null, null);
+        GameWebSocket gameWebSocket = new GameWebSocket(null, null, null) {
+            @Override
+            public boolean createGameRoom(String gameId, String username1, String username2) {
+                return true;
+            }
+        };
+        LobbyWebSocket lobbyWebSocket = new LobbyWebSocket(null, null, null, gameWebSocket);
         TestSession host = new TestSession("host");
         TestSession guest = new TestSession("guest");
         Room room = new Room(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { initParticlesEngine } from "@tsparticles/react";
 import { loadSlim } from "@tsparticles/slim";
 import { useDeckStates } from "./hooks/useDeckStates.ts";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import Profile from "./pages/Profile.tsx";
 import LoginPage from "./pages/LoginPage.tsx";
 import RecoveryPage from "./pages/RecoveryPage.tsx";
@@ -24,9 +24,13 @@ function App() {
     const fetchDecks = useDeckStates((state) => state.fetchDecks);
     const setParticlesInitialized = useGeneralStates((state) => state.setParticlesInitialized);
 
-    useEffect(() => me(), [me]);
+    useEffect(() => {
+        me();
+    }, [me]);
 
-    useEffect(() => fetchCards(), [fetchCards]);
+    useEffect(() => {
+        fetchCards();
+    }, [fetchCards]);
 
     useEffect(() => {
         if (user.length && user !== "anonymousUser") fetchDecks();
@@ -46,7 +50,7 @@ function App() {
                     <Route path="/decks" element={<Decks />} />
                     <Route path="/deckbuilder" element={<Deckbuilder />} />
                     <Route path="/deckbuilder/:id" element={<Deckbuilder />} />
-                    <Route path="/game" element={<GamePage />} />
+                    <Route path="/game" element={<GameRoute />} />
                     <Route path="/test" element={<DeckTest />} />
                     <Route path="/administration" element={<Administration />} />
                     <Route path="/*" element={<Navigate to="/" />} />
@@ -57,6 +61,13 @@ function App() {
             </Routes>
         </>
     );
+}
+
+function GameRoute() {
+    const location = useLocation();
+    const gameEntryConfirmed = (location.state as { gameEntryConfirmed?: boolean } | null)?.gameEntryConfirmed;
+
+    return gameEntryConfirmed ? <GamePage /> : <Navigate to="/" replace />;
 }
 
 export default App;

--- a/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
+++ b/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
@@ -86,10 +86,11 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
     return highlightedParts.flatMap((item) => {
         if (typeof item === "string") {
             const lines = item.split("\n");
-            return lines.flatMap((line, index) => [
-                <span key={uid()}>{line}</span>,
-                index !== lines.length - 1 ? <br key={uid()} /> : <></>,
-            ]);
+            return lines.flatMap((line, index) => {
+                const lineParts = [<span key={uid()}>{line}</span>];
+                if (index !== lines.length - 1) lineParts.push(<br key={uid()} />);
+                return lineParts;
+            });
         }
         return [item];
     });

--- a/frontend/src/components/game/GameChatLog.tsx
+++ b/frontend/src/components/game/GameChatLog.tsx
@@ -22,7 +22,7 @@ export default function GameChatLog({ matchInfo, sendChatMessage }: Partial<WSUt
                 {messages.map((message, index) => {
                     if (message.startsWith("[STARTING_PLAYER]≔")) {
                         return (
-                            <UpdateMessage style={{ background: "rgba(255, 215, 0, 0.25)" }}>
+                            <UpdateMessage key={`starting-player-${index}`} style={{ background: "rgba(255, 215, 0, 0.25)" }}>
                                 <p>FIRST TURN: {message.split("≔")[1]}</p>
                             </UpdateMessage>
                         );

--- a/frontend/src/components/game/ModalDialog/EndModal.tsx
+++ b/frontend/src/components/game/ModalDialog/EndModal.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import ModalDialog from "./ModalDialog.tsx";
 import { useGameUIStates } from "../../../hooks/useGameUIStates.ts";
+import { returnToLobby } from "../../../utils/returnToLobby.ts";
 
 export default function EndModal() {
     const isEndDialogOpen = useGameUIStates((state) => state.isEndDialogOpen);
@@ -12,10 +13,7 @@ export default function EndModal() {
     const buttonProps = [
         {
             text: "EXIT",
-            onClick: () => {
-                setIsEndDialogOpen(false);
-                navigate("/lobby");
-            },
+            onClick: () => returnToLobby(navigate),
             color: "#FCCB0B",
         },
         { text: "CLOSE DIALOG", onClick: () => setIsEndDialogOpen(false), color: "#FCCB0B" },

--- a/frontend/src/components/game/ModalDialog/ReturnToGameLobbyModal.tsx
+++ b/frontend/src/components/game/ModalDialog/ReturnToGameLobbyModal.tsx
@@ -1,0 +1,15 @@
+import ModalDialog from "./ModalDialog.tsx";
+
+type Props = {
+    onConfirm: () => void;
+    onCancel: () => void;
+};
+
+export default function ReturnToGameLobbyModal({ onConfirm, onCancel }: Props) {
+    const buttonProps = [
+        { text: "YES", onClick: onConfirm, color: "#27C06E" },
+        { text: "NO", onClick: onCancel, color: "#C03427" },
+    ];
+
+    return <ModalDialog text="Would you like to return back to the Game Lobby?" buttonProps={buttonProps} />;
+}

--- a/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
@@ -26,6 +26,7 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
     const iconWidth = useGeneralStates((state) => state.cardWidth * 0.45);
     const gameLobbyRoomId = useGameBoardStates((state) => state.gameLobbyRoomId);
     const setGameId = useGameBoardStates((state) => state.setGameId);
+    const clearBoard = useGameBoardStates((state) => state.clearBoard);
     const navigate = useNavigate();
 
     const [restartRequestModal, setRestartRequestModal] = useState<boolean>(false);
@@ -35,7 +36,9 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
     function returnToGameLobby() {
         if (!wsUtils || !gameLobbyRoomId) return;
         setReturnToGameLobbyModal(false);
-        wsUtils.sendMessage(`${wsUtils.matchInfo.gameId}:/surrender`);
+        wsUtils.sendMessage(`${wsUtils.matchInfo.gameId}:/returnToLobby`);
+        clearBoard();
+        localStorage.removeItem("boardStore");
         setGameId("");
         navigate("/lobby");
     }

--- a/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
@@ -17,30 +17,35 @@ import KeyboardReturnTwoToneIcon from "@mui/icons-material/KeyboardReturnTwoTone
 import RestartRequestModal from "../ModalDialog/RestartRequestModal.tsx";
 import ReturnToGameLobbyModal from "../ModalDialog/ReturnToGameLobbyModal.tsx";
 import SurrenderModal from "../ModalDialog/SurrenderModal.tsx";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
 import { useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
-import { useNavigate } from "react-router-dom";
+import { notifyError } from "../../../utils/toasts.ts";
 
 export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
     const iconWidth = useGeneralStates((state) => state.cardWidth * 0.45);
     const gameLobbyRoomId = useGameBoardStates((state) => state.gameLobbyRoomId);
-    const setGameId = useGameBoardStates((state) => state.setGameId);
-    const clearBoard = useGameBoardStates((state) => state.clearBoard);
-    const navigate = useNavigate();
 
     const [restartRequestModal, setRestartRequestModal] = useState<boolean>(false);
     const [surrenderModal, setSurrenderModal] = useState<boolean>(false);
     const [returnToGameLobbyModal, setReturnToGameLobbyModal] = useState<boolean>(false);
+    const returnTimeoutRef = useRef<number | null>(null);
+
+    useEffect(
+        () => () => {
+            if (returnTimeoutRef.current !== null) window.clearTimeout(returnTimeoutRef.current);
+        },
+        []
+    );
 
     function returnToGameLobby() {
         if (!wsUtils || !gameLobbyRoomId) return;
         setReturnToGameLobbyModal(false);
         wsUtils.sendMessage(`${wsUtils.matchInfo.gameId}:/returnToLobby`);
-        clearBoard();
-        localStorage.removeItem("boardStore");
-        setGameId("");
-        navigate("/lobby");
+        returnTimeoutRef.current = window.setTimeout(() => {
+            notifyError("The server did not confirm returning to the lobby. Please restart the backend and try again.");
+            returnTimeoutRef.current = null;
+        }, 3000);
     }
 
     return (

--- a/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
@@ -13,16 +13,29 @@ import { WSUtils } from "../../../pages/GamePage.tsx";
 import PlayerCard from "../PlayerCard.tsx";
 import ReportButton from "../ReportButton.tsx";
 import { Flag as SurrenderIcon, RestartAlt as RestartIcon } from "@mui/icons-material";
+import KeyboardReturnTwoToneIcon from "@mui/icons-material/KeyboardReturnTwoTone";
 import RestartRequestModal from "../ModalDialog/RestartRequestModal.tsx";
 import SurrenderModal from "../ModalDialog/SurrenderModal.tsx";
 import { useState } from "react";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
+import { useGameBoardStates } from "../../../hooks/useGameBoardStates.ts";
+import { useNavigate } from "react-router-dom";
 
 export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
     const iconWidth = useGeneralStates((state) => state.cardWidth * 0.45);
+    const gameLobbyRoomId = useGameBoardStates((state) => state.gameLobbyRoomId);
+    const setGameId = useGameBoardStates((state) => state.setGameId);
+    const navigate = useNavigate();
 
     const [restartRequestModal, setRestartRequestModal] = useState<boolean>(false);
     const [surrenderModal, setSurrenderModal] = useState<boolean>(false);
+
+    function returnToGameLobby() {
+        if (!wsUtils || !gameLobbyRoomId) return;
+        wsUtils.sendMessage(`${wsUtils.matchInfo.gameId}:/surrender`);
+        setGameId("");
+        navigate("/lobby");
+    }
 
     return (
         <LayoutContainer>
@@ -34,13 +47,28 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
                     {surrenderModal && <SurrenderModal setSurrenderModal={setSurrenderModal} wsUtils={wsUtils} />}
                     <ReportButton matchInfo={wsUtils.matchInfo} iconFontSize={`${iconWidth - 5}px`} />
 
-                    <PanelButton
-                        className={"button"}
-                        onClick={() => setSurrenderModal(true)}
-                        style={{ gridArea: "surrender", transform: `translate(-4px, -1px)` }}
-                    >
-                        <SurrenderIcon className={"button"} sx={{ fontSize: iconWidth - 5, color: "blanchedalmond" }} />
-                    </PanelButton>
+                    {gameLobbyRoomId ? (
+                        <PanelButton
+                            className="button"
+                            onClick={returnToGameLobby}
+                            title="Return to Game Lobby"
+                            aria-label="Return to Game Lobby"
+                            style={{ gridArea: "surrender", transform: `translate(-4px, -1px)` }}
+                        >
+                            <KeyboardReturnTwoToneIcon sx={{ fontSize: iconWidth - 5, color: "white" }} />
+                        </PanelButton>
+                    ) : (
+                        <PanelButton
+                            className={"button"}
+                            onClick={() => setSurrenderModal(true)}
+                            style={{ gridArea: "surrender", transform: `translate(-4px, -1px)` }}
+                        >
+                            <SurrenderIcon
+                                className={"button"}
+                                sx={{ fontSize: iconWidth - 5, color: "blanchedalmond" }}
+                            />
+                        </PanelButton>
+                    )}
                     <PanelButton
                         className={"button"}
                         onClick={() => setRestartRequestModal(true)}

--- a/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
@@ -15,6 +15,7 @@ import ReportButton from "../ReportButton.tsx";
 import { Flag as SurrenderIcon, RestartAlt as RestartIcon } from "@mui/icons-material";
 import KeyboardReturnTwoToneIcon from "@mui/icons-material/KeyboardReturnTwoTone";
 import RestartRequestModal from "../ModalDialog/RestartRequestModal.tsx";
+import ReturnToGameLobbyModal from "../ModalDialog/ReturnToGameLobbyModal.tsx";
 import SurrenderModal from "../ModalDialog/SurrenderModal.tsx";
 import { useState } from "react";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
@@ -29,9 +30,11 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
 
     const [restartRequestModal, setRestartRequestModal] = useState<boolean>(false);
     const [surrenderModal, setSurrenderModal] = useState<boolean>(false);
+    const [returnToGameLobbyModal, setReturnToGameLobbyModal] = useState<boolean>(false);
 
     function returnToGameLobby() {
         if (!wsUtils || !gameLobbyRoomId) return;
+        setReturnToGameLobbyModal(false);
         wsUtils.sendMessage(`${wsUtils.matchInfo.gameId}:/surrender`);
         setGameId("");
         navigate("/lobby");
@@ -45,12 +48,18 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
                         <RestartRequestModal setRestartRequestModal={setRestartRequestModal} wsUtils={wsUtils} />
                     )}
                     {surrenderModal && <SurrenderModal setSurrenderModal={setSurrenderModal} wsUtils={wsUtils} />}
+                    {returnToGameLobbyModal && (
+                        <ReturnToGameLobbyModal
+                            onConfirm={returnToGameLobby}
+                            onCancel={() => setReturnToGameLobbyModal(false)}
+                        />
+                    )}
                     <ReportButton matchInfo={wsUtils.matchInfo} iconFontSize={`${iconWidth - 5}px`} />
 
                     {gameLobbyRoomId ? (
                         <PanelButton
                             className="button"
-                            onClick={returnToGameLobby}
+                            onClick={() => setReturnToGameLobbyModal(true)}
                             title="Return to Game Lobby"
                             aria-label="Return to Game Lobby"
                             style={{ gridArea: "surrender", transform: `translate(-4px, -1px)` }}

--- a/frontend/src/components/game/OpponentBoardSide/OpponentEventUtils/OpponentEventUtils.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentEventUtils/OpponentEventUtils.tsx
@@ -6,12 +6,13 @@ import firstAnimation from "../../../../assets/lotties/net-ball.json";
 import Lottie from "lottie-react";
 import { WifiOffRounded as OfflineIcon } from "@mui/icons-material";
 import { useGameUIStates } from "../../../../hooks/useGameUIStates.ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import EmoteRender from "../../EmoteRender.tsx";
 
 export default function OpponentEventUtils({ wsUtils }: { wsUtils?: WSUtils }) {
     const bootStage = useGameBoardStates((state) => state.bootStage);
     const isOpponentOnline = useGameBoardStates((state) => state.isOpponentOnline);
+    const opponentReconnectDeadline = useGameBoardStates((state) => state.opponentReconnectDeadline);
     const startingPlayer = useGameBoardStates((state) => state.startingPlayer);
 
     const opponentEmote = useGameUIStates((state) => state.opponentEmote);
@@ -19,6 +20,17 @@ export default function OpponentEventUtils({ wsUtils }: { wsUtils?: WSUtils }) {
     const isFirst = startingPlayer === wsUtils?.matchInfo.opponentName;
 
     const [hasChildren, setHasChildren] = useState(false);
+    const [now, setNow] = useState(Date.now());
+
+    useEffect(() => {
+        if (isOpponentOnline || opponentReconnectDeadline === null) return;
+        setNow(Date.now());
+        const interval = window.setInterval(() => setNow(Date.now()), 250);
+        return () => window.clearInterval(interval);
+    }, [isOpponentOnline, opponentReconnectDeadline]);
+
+    const remainingSeconds = Math.max(0, Math.ceil(((opponentReconnectDeadline ?? now) - now) / 1000));
+    const reconnectTime = `${Math.floor(remainingSeconds / 60)}:${String(remainingSeconds % 60).padStart(2, "0")}`;
 
     return (
         <Container
@@ -33,7 +45,10 @@ export default function OpponentEventUtils({ wsUtils }: { wsUtils?: WSUtils }) {
             ) : (
                 <>
                     {!isOpponentOnline ? (
-                        <OfflineIcon fontSize={"large"} color={"error"} />
+                        <ReconnectStatus>
+                            <OfflineIcon fontSize={"large"} color={"error"} />
+                            <span>Waiting for player to reconnect {reconnectTime}</span>
+                        </ReconnectStatus>
                     ) : (
                         <>
                             {bootStage === BootStage.SHOW_STARTING_PLAYER && (
@@ -109,4 +124,16 @@ const Container = styled.div<{ hasChildren: boolean }>`
             box-shadow: inset 0 0 3px 1px rgba(146, 255, 245, 0.15);
         }
     }
+`;
+
+const ReconnectStatus = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 12px;
+    color: papayawhip;
+    font-family: Cousine, sans-serif;
+    font-size: clamp(12px, 1.1vw, 18px);
+    text-align: center;
 `;

--- a/frontend/src/components/game/OpponentBoardSide/OpponentHand.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentHand.tsx
@@ -26,6 +26,7 @@ export default function OpponentHand() {
         <Container cardCount={opponentHand.length}>
             {opponentHand.map((card, index) => (
                 <div
+                    key={card.id}
                     onContextMenu={(e) =>
                         showOpponentHandCardMenu({
                             event: e,
@@ -40,7 +41,6 @@ export default function OpponentHand() {
                     style={{ position: "absolute", left: offset + index * effectiveSpacing }}
                 >
                     <Card
-                        key={card.id}
                         card={card}
                         location={"opponentHand"}
                         style={{

--- a/frontend/src/hooks/useDeckStates.ts
+++ b/frontend/src/hooks/useDeckStates.ts
@@ -181,11 +181,11 @@ export const useDeckStates = create<State>((set, get) => ({
         set({ isLoading: true });
         axios
             .get("/api/profile/decks")
-            .then((res) => res.data)
-            .catch(console.error)
-            .then((data) => {
-                set({ decks: data });
+            .then((res) => {
+                if (!Array.isArray(res.data)) throw new Error("Deck API returned a non-array response");
+                set({ decks: res.data });
             })
+            .catch(console.error)
             .finally(() => set({ isLoading: false }));
     },
 
@@ -193,15 +193,15 @@ export const useDeckStates = create<State>((set, get) => ({
         set({ isLoading: true });
         axios
             .get("/api/profile/cards")
-            .then((res) => res.data)
-            .catch(console.error)
-            .then((data) => set({ fetchedCards: data.map((card: CardType) => ({ ...card, id: uid() })) }))
+            .then((res) => {
+                if (!Array.isArray(res.data)) throw new Error("Card API returned a non-array response");
+                set({ fetchedCards: res.data.map((card: CardType) => ({ ...card, id: uid() })) });
+            })
             .then(() =>
-                axios
-                    .get("/api/profile/decks")
-                    .then((res) => res.data)
-                    .catch(console.error)
-                    .then((data) => set({ decks: data }))
+                axios.get("/api/profile/decks").then((res) => {
+                    if (!Array.isArray(res.data)) throw new Error("Deck API returned a non-array response");
+                    set({ decks: res.data });
+                })
             )
             .then(() => {
                 const savedDeckIdOrder: string[] | null = JSON.parse(localStorage.getItem("deckIdOrder") ?? "null");
@@ -220,6 +220,7 @@ export const useDeckStates = create<State>((set, get) => ({
 
                 setOrderedDecks([...orderedDecks, ...newDecks]);
             })
+            .catch(console.error)
             .finally(() => set({ isLoading: false }));
     },
 
@@ -238,10 +239,9 @@ export const useDeckStates = create<State>((set, get) => ({
         set({ isLoading: true });
         axios
             .get("/api/profile/cards")
-            .then((res) => res.data)
-            .catch(console.error)
-            .then((data) => {
-                const cardsWithId: CardTypeWithId[] = data.map((card: CardType) => ({
+            .then((res) => {
+                if (!Array.isArray(res.data)) throw new Error("Card API returned a non-array response");
+                const cardsWithId: CardTypeWithId[] = res.data.map((card: CardType) => ({
                     ...card,
                     id: uid(),
                 }));
@@ -250,6 +250,7 @@ export const useDeckStates = create<State>((set, get) => ({
                     filteredCards: cardsWithId,
                 });
             })
+            .catch(console.error)
             .finally(() => set({ isLoading: false }));
     },
 

--- a/frontend/src/hooks/useGameBoardStates.ts
+++ b/frontend/src/hooks/useGameBoardStates.ts
@@ -582,6 +582,9 @@ export const useGameBoardStates = create<State>()((set, get) => ({
                 // Set memory values
                 myMemory: isPlayer1 ? boardState.player1Memory : boardState.player2Memory,
                 opponentMemory: isPlayer1 ? boardState.player2Memory : boardState.player1Memory,
+                ...(boardState.phase && { phase: boardState.phase }),
+                ...(boardState.usernameTurn && { usernameTurn: boardState.usernameTurn }),
+                ...(boardState.bootStage !== undefined && { bootStage: boardState.bootStage }),
             });
         } else {
             // Handle GameStart format (initial distribution)

--- a/frontend/src/hooks/useGameBoardStates.ts
+++ b/frontend/src/hooks/useGameBoardStates.ts
@@ -214,6 +214,7 @@ export type State = BoardState & {
     setAllMessages: (messages: string[]) => void;
     stackSliceIndex: number;
     isOpponentOnline: boolean;
+    opponentReconnectDeadline: number | null;
     startingPlayer: string;
 
     // --------------------------------------------------------
@@ -262,6 +263,7 @@ export type State = BoardState & {
     toggleIsHandHidden: () => void;
     setStackSliceIndex: (index: number) => void;
     setIsOpponentOnline: (isOpponentOnline: boolean) => void;
+    setOpponentReconnectDeadline: (deadline: number | null) => void;
     setStartingPlayer: (side: SIDE | "") => void;
 
     flipCard: (cardId: string, location: string) => void;
@@ -446,6 +448,7 @@ export const useGameBoardStates = create<State>()((set, get) => ({
     messages: [],
     stackSliceIndex: 0,
     isOpponentOnline: true,
+    opponentReconnectDeadline: null,
     startingPlayer: "",
 
     hasDecidedMulligan: false,
@@ -468,6 +471,7 @@ export const useGameBoardStates = create<State>()((set, get) => ({
             myAttackPhase: false,
             bootStage: BootStage.CLEAR,
             isOpponentOnline: true,
+            opponentReconnectDeadline: null,
             hasDecidedMulligan: false,
             messages: [],
             player1: { avatarName: "", mainSleeveName: "", eggSleeveName: "", username: "" },
@@ -988,6 +992,8 @@ export const useGameBoardStates = create<State>()((set, get) => ({
     setStackSliceIndex: (index) => set({ stackSliceIndex: index }),
 
     setIsOpponentOnline: (isOpponentOnline) => set({ isOpponentOnline }),
+
+    setOpponentReconnectDeadline: (opponentReconnectDeadline) => set({ opponentReconnectDeadline }),
 
     setStartingPlayer: (startingPlayer) => set({ startingPlayer }),
 

--- a/frontend/src/hooks/useGameBoardStates.ts
+++ b/frontend/src/hooks/useGameBoardStates.ts
@@ -937,7 +937,8 @@ export const useGameBoardStates = create<State>()((set, get) => ({
     setBootStage: (stage) => set({ bootStage: stage }),
 
     setGameId: (gameId) => {
-        localStorage.setItem("gameId", gameId);
+        if (gameId) localStorage.setItem("gameId", gameId);
+        else localStorage.removeItem("gameId");
         set({ gameId });
     },
 

--- a/frontend/src/hooks/useGameBoardStates.ts
+++ b/frontend/src/hooks/useGameBoardStates.ts
@@ -181,6 +181,7 @@ type GameDistribution = {
 
 export type State = BoardState & {
     gameId: string;
+    gameLobbyRoomId: string;
 
     cardIdWithEffect: string;
     cardIdWithTarget: string;
@@ -254,6 +255,7 @@ export type State = BoardState & {
     setCardToSend: (cardToSend: { card: CardTypeGame; location: string } | null) => void;
     setBootStage: (phase: BootStage) => void;
     setGameId: (gameId: string) => void;
+    setGameLobbyRoomId: (roomId: string) => void;
     setInheritCardInfo: (inheritedEffects: string[]) => void;
     setModifiers: (cardId: string, location: string, modifiers: CardModifiers) => void;
     getCardLocationById: (id: string) => string;
@@ -418,6 +420,7 @@ const fieldDefaultValues = {
 
 export const useGameBoardStates = create<State>()((set, get) => ({
     gameId: localStorage.getItem("gameId") || "",
+    gameLobbyRoomId: localStorage.getItem("gameLobbyRoomId") || "",
 
     cardIdWithEffect: "",
     cardIdWithTarget: "",
@@ -936,6 +939,12 @@ export const useGameBoardStates = create<State>()((set, get) => ({
     setGameId: (gameId) => {
         localStorage.setItem("gameId", gameId);
         set({ gameId });
+    },
+
+    setGameLobbyRoomId: (roomId) => {
+        if (roomId) localStorage.setItem("gameLobbyRoomId", roomId);
+        else localStorage.removeItem("gameLobbyRoomId");
+        set({ gameLobbyRoomId: roomId });
     },
 
     setInheritCardInfo: (inheritedEffects) => set({ inheritCardInfo: inheritedEffects }),

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -8,6 +8,7 @@ import { useSound } from "./useSound.ts";
 import { useGameUIStates } from "./useGameUIStates.ts";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
+import { returnToLobby } from "../utils/returnToLobby.ts";
 
 const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 const websocketURL = `${websocketProtocol}//${window.location.host}/api/ws/game`;
@@ -414,10 +415,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                     break;
                 }
                 case "[RETURN_TO_LOBBY]": {
-                    clearBoard();
-                    localStorage.removeItem("boardStore");
-                    setGameId("");
-                    navigate("/lobby");
+                    returnToLobby(navigate);
                     break;
                 }
                 case "[SECURITY_VIEWED]": {

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -6,6 +6,8 @@ import { useGameBoardStates } from "./useGameBoardStates.ts";
 import { useGeneralStates } from "./useGeneralStates.ts";
 import { useSound } from "./useSound.ts";
 import { useGameUIStates } from "./useGameUIStates.ts";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 
 const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 const websocketURL = `${websocketProtocol}//${window.location.host}/api/ws/game`;
@@ -17,6 +19,7 @@ type UseGameWebSocketProps = {
 
 type UseGameWebSocketReturn = {
     sendMessage: SendMessage;
+    isGameReady: boolean;
 };
 
 function getValidOffset(fieldNumber: number, currentOffset: number) {
@@ -44,6 +47,8 @@ function getValidOffset(fieldNumber: number, currentOffset: number) {
  */
 export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameWebSocketReturn {
     const { clearAttackAnimation, restartAttackAnimation } = props;
+    const navigate = useNavigate();
+    const [isGameReady, setIsGameReady] = useState(false);
 
     const user = useGeneralStates((state) => state.user);
 
@@ -57,6 +62,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
     const setOpponentEmote = useGameUIStates((state) => state.setOpponentEmote);
 
     const gameId = useGameBoardStates((state) => state.gameId);
+    const setGameId = useGameBoardStates((state) => state.setGameId);
     const setBootStage = useGameBoardStates((state) => state.setBootStage);
     const setPlayers = useGameBoardStates((state) => state.setPlayers);
     const setPhase = useGameBoardStates((state) => state.setPhase);
@@ -80,6 +86,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
     const unsuspendAll = useGameBoardStates((state) => state.unsuspendAll);
     const setStartingPlayer = useGameBoardStates((state) => state.setStartingPlayer);
     const setIsOpponentOnline = useGameBoardStates((state) => state.setIsOpponentOnline);
+    const setOpponentReconnectDeadline = useGameBoardStates((state) => state.setOpponentReconnectDeadline);
     const flipCard = useGameBoardStates((state) => state.flipCard);
 
     const setArrowFrom = useGameUIStates((state) => state.setArrowFrom);
@@ -121,6 +128,20 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
         onOpen: () => websocket.sendMessage("/joinGame:" + gameId),
 
         onMessage: (event) => {
+            if (event.data === "[GAME_JOINED]") {
+                setIsGameReady(true);
+                return;
+            }
+
+            if (event.data === "[GAME_JOIN_REJECTED]") {
+                setIsGameReady(false);
+                clearBoard();
+                setGameId("");
+                notifyInfo("That game is no longer available. Return to the lobby to start or rejoin a match.");
+                navigate("/", { replace: true });
+                return;
+            }
+
             if (event.data === "[START_GAME]") {
                 setStartingPlayer("");
                 setMyAttackPhase(false);
@@ -392,6 +413,13 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                     setEndDialogText("🎉 Your opponent surrendered!");
                     break;
                 }
+                case "[RETURN_TO_LOBBY]": {
+                    clearBoard();
+                    localStorage.removeItem("boardStore");
+                    setGameId("");
+                    navigate("/lobby");
+                    break;
+                }
                 case "[SECURITY_VIEWED]": {
                     notifyInfo("Opponent opened Security Stack!");
                     break;
@@ -427,20 +455,29 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                     unsuspendAll(SIDE.OPPONENT);
                     break;
                 }
-                case "[OPPONENT_DISCONNECTED]": {
-                    setIsOpponentOnline(false);
-                    break;
-                }
                 case "[OPPONENT_RECONNECTED]": {
                     setIsOpponentOnline(true);
+                    setOpponentReconnectDeadline(null);
                     break;
                 }
                 default: {
+                    if (event.data.startsWith("[OPPONENT_DISCONNECTED]")) {
+                        const deadline = Number(event.data.split(":", 2)[1]);
+                        setIsOpponentOnline(false);
+                        setOpponentReconnectDeadline(
+                            Number.isFinite(deadline) ? deadline : Date.now() + 2 * 60 * 1000
+                        );
+                    }
+                    if (event.data.startsWith("[PLAYER_RETURNED_TO_LOBBY]:")) {
+                        const player = event.data.substring("[PLAYER_RETURNED_TO_LOBBY]:".length);
+                        setIsEndDialogOpen(true);
+                        setEndDialogText(`${player} has returned to the lobby.`);
+                    }
                     break;
                 }
             }
         },
     });
 
-    return { sendMessage: websocket.sendMessage };
+    return { sendMessage: websocket.sendMessage, isGameReady };
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import {BrowserRouter} from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-      <BrowserRouter>
-          <App/>
-      </BrowserRouter>
-  </React.StrictMode>,
+    <BrowserRouter>
+        <App/>
+    </BrowserRouter>,
 )

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -109,7 +109,7 @@ export default function GamePage() {
         [playAttackSfx, playEffectAttackSfx]
     );
 
-    const { sendMessage } = useGameWebSocket({
+    const { sendMessage, isGameReady } = useGameWebSocket({
         clearAttackAnimation,
         restartAttackAnimation,
     });
@@ -184,7 +184,9 @@ export default function GamePage() {
     const boardContainerRef = useRef<HTMLDivElement>(null);
     const height = boardContainerRef.current ? Math.max(window.outerHeight - 148, 800) : undefined;
 
-    useLayoutEffect(() => window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0), []);
+    useLayoutEffect(() => {
+        window.scrollTo(document.documentElement.scrollWidth - window.innerWidth, 0);
+    }, []);
 
     // Determine backend based on touch capability
     const backend = "ontouchstart" in window ? TouchBackend : HTML5Backend;
@@ -233,6 +235,10 @@ export default function GamePage() {
         </BoardLayout>
     );
 
+    if (!isGameReady) {
+        return <GameLoadingScreen>Confirming your active game…</GameLoadingScreen>;
+    }
+
     return (
         <Container ref={boardContainerRef}>
             <GameBackground />
@@ -266,6 +272,15 @@ export default function GamePage() {
         </Container>
     );
 }
+
+const GameLoadingScreen = styled.div`
+    display: grid;
+    place-items: center;
+    min-height: 100vh;
+    background: #080b12;
+    color: white;
+    font-size: 1.1rem;
+`;
 
 const Container = styled.div`
     display: flex;

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -105,6 +105,7 @@ export default function Lobby() {
 
     const gameId = useGameBoardStates((state) => state.gameId);
     const setGameId = useGameBoardStates((state) => state.setGameId);
+    const setGameLobbyRoomId = useGameBoardStates((state) => state.setGameLobbyRoomId);
     const clearBoard = useGameBoardStates((state) => state.clearBoard);
     const setIsOpponentOnline = useGameBoardStates((state) => state.setIsOpponentOnline);
 
@@ -227,6 +228,7 @@ export default function Lobby() {
 
                 if (event.data === "[LEAVE_ROOM]") {
                     setJoinedRoom(null);
+                    setGameLobbyRoomId("");
                     setPrivateMessages([]);
                     setIsLoading(false);
                     playJoinSfx(); // new sound?
@@ -234,6 +236,7 @@ export default function Lobby() {
 
                 if (event.data === "[KICKED]") {
                     setJoinedRoom(null);
+                    setGameLobbyRoomId("");
                     setPrivateMessages([]);
                     playKickSfx();
                 }
@@ -251,6 +254,15 @@ export default function Lobby() {
                     localStorage.setItem("isReported", JSON.stringify(false)); // see ReportButton.tsx
                     localStorage.removeItem("boardStore");
                     const gameId = event.data.substring("[COMPUTE_GAME]:".length);
+                    setGameLobbyRoomId("");
+                    startGameSequence(gameId);
+                }
+
+                if (event.data.startsWith("[COMPUTE_ROOM_GAME]:")) {
+                    localStorage.setItem("isReported", JSON.stringify(false));
+                    localStorage.removeItem("boardStore");
+                    const [gameId, roomId] = event.data.substring("[COMPUTE_ROOM_GAME]:".length).split(":", 2);
+                    setGameLobbyRoomId(roomId);
                     startGameSequence(gameId);
                 }
 

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -103,7 +103,6 @@ export default function Lobby() {
 
     const decks = useDeckStates((state) => state.decks);
 
-    const gameId = useGameBoardStates((state) => state.gameId);
     const setGameId = useGameBoardStates((state) => state.setGameId);
     const setGameLobbyRoomId = useGameBoardStates((state) => state.setGameLobbyRoomId);
     const clearBoard = useGameBoardStates((state) => state.clearBoard);
@@ -153,10 +152,10 @@ export default function Lobby() {
 
     const navigate = useNavigate();
 
-    function handleReconnect() {
+    function handleReturnToGame() {
         setIsOpponentOnline(true);
         setIsLoading(false);
-        navigate("/game");
+        navigate("/game", { state: { gameEntryConfirmed: true } });
     }
 
     function handleOnlineUsersClick(event: ReactMouseEvent<HTMLButtonElement>) {
@@ -283,9 +282,9 @@ export default function Lobby() {
                 }
 
                 if (event.data.startsWith("[RECONNECT_ENABLED]:")) {
-                    const matchingRoomId = event.data.substring("[RECONNECT_ENABLED]:".length);
-                    setIsRejoinable(matchingRoomId === gameId);
-                    // gameId could be set to older matching room id here, but not sure if this makes sense
+                    const reconnectGameId = event.data.substring("[RECONNECT_ENABLED]:".length);
+                    setGameId(reconnectGameId);
+                    setIsRejoinable(true);
                 }
 
                 if (event.data === "[RECONNECT_DISABLED]") {
@@ -381,7 +380,7 @@ export default function Lobby() {
             clearBoard();
             setIsLoading(false);
             setJoinedRoom(null);
-            navigate("/game");
+            navigate("/game", { state: { gameEntryConfirmed: true } });
         }, 3150);
         return () => clearTimeout(timer);
     }
@@ -412,7 +411,9 @@ export default function Lobby() {
     const initialFetch = useCallback(() => {
         getActiveDeck();
     }, [getActiveDeck]);
-    useEffect(() => initialFetch(), [initialFetch]);
+    useEffect(() => {
+        initialFetch();
+    }, [initialFetch]);
 
     useEffect(() => {
         const timeout = window.setTimeout(() => setDebouncedPlayerSearch(playerSearch), 250);
@@ -420,7 +421,12 @@ export default function Lobby() {
     }, [playerSearch]);
 
     useEffect(() => {
-        axios.get(`/api/profile/decks/${activeDeckId}`).then((res) => setDeckObject(res.data as DeckType));
+        if (!activeDeckId) return;
+
+        axios
+            .get(`/api/profile/decks/${activeDeckId}`)
+            .then((res) => setDeckObject(res.data as DeckType))
+            .catch(console.error);
     }, [activeDeckId]);
 
     useEffect(() => {
@@ -520,8 +526,6 @@ export default function Lobby() {
                 <SoundBar opened />
 
                 {/*TODO: Add own name plate here*/}
-
-                {isRejoinable && <Button onClick={handleReconnect}>RECONNECT</Button>}
 
                 <OnlineUsers
                     type="button"
@@ -630,7 +634,9 @@ export default function Lobby() {
                             <CardTitle style={{ marginBottom: 0 }}>{joinedRoom?.name ?? "Room"}</CardTitle>
                             <CardTitle style={{ color: "var(--lobby-accent)" }}>{joinedRoom ? "" : "Host"}</CardTitle>
                             <CardTitle style={{ gridColumn: "span 2" }}>{joinedRoom ? "" : "Settings"}</CardTitle>
-                            {joinedRoom ? (
+                            {isRejoinable ? (
+                                <Button onClick={handleReturnToGame}>RETURN TO GAME</Button>
+                            ) : joinedRoom ? (
                                 user === joinedRoom.hostName ? (
                                     <Button disabled={startGameDisabled} onClick={handleStartGame}>
                                         START GAME

--- a/frontend/src/utils/returnToLobby.ts
+++ b/frontend/src/utils/returnToLobby.ts
@@ -1,0 +1,15 @@
+import { NavigateFunction } from "react-router-dom";
+import { useGameBoardStates } from "../hooks/useGameBoardStates.ts";
+import { useGameUIStates } from "../hooks/useGameUIStates.ts";
+
+export function returnToLobby(navigate: NavigateFunction) {
+    const boardState = useGameBoardStates.getState();
+
+    boardState.clearBoard();
+    boardState.setGameId("");
+    boardState.setGameLobbyRoomId("");
+    useGameUIStates.getState().setIsEndDialogOpen(false);
+    localStorage.removeItem("boardStore");
+
+    navigate("/", { replace: true });
+}


### PR DESCRIPTION
## Summary

Addresses: https://github.com/WE-Kaito/digimon-tcg-simulator/issues/325 

  Improves game reconnection and lobby-return behavior for both Quick Play and lobby matches.

  - Prevents direct navigation to /game unless game entry or reconnection was confirmed.
  - Allows disconnected players to reconnect only during the two-minute grace period.
  - Removes the “RETURN TO GAME” option once a player surrenders or the game ends.
  - Properly destroys surrendered games so they cannot be rejoined.
  - Adds confirmation and synchronized handling when returning to the lobby.
  - Removes disconnected players when the host returns to the game lobby.
  - Clears stale game and lobby state when leaving, being kicked, or failing to rejoin.
  - Adds backend tests for game joining, surrender, reconnection, and lobby-return behavior.

  ## Testing

  - Verified successful game entry and rejected stale-game entry.
  - Verified disconnected players can reconnect during the grace period.
  - Verified surrender removes the game and disables reconnection.
  - Verified host lobby return removes disconnected players.
  - Backend tests pass: 5 tests, 0 failures.

## Notes
The change routes users through the lobby after login/reconnection, but treat that as UX control rather than the actual security/state guarantee.

  For this project, I use this flow:

  1. User logs in and enters the lobby.
  2. Lobby asks the server whether that authenticated user has an active game.
  3. If so, show “Return to game” or automatically redirect after confirmation.
  4. /game displays a loading state until the server validates membership and sends [BOARD_STATE].
  5. If no active game exists, redirect to / and clear stale local game state.

  This is safer because the server already owns the authoritative board state and sends it during reconnection. A closed browser should therefore
  reconstruct the UI from [BOARD_STATE], not trust the board remaining in Zustand/local storage.

  The more important issue is backend behavior: Code/digimon-tcg-simulator/backend/src/main/java/com/github/wekaito/backend/websocket/game/
  GameWebSocket.java:531 currently creates a new room when /joinGame references a nonexistent game. That means a stale gameId can potentially recreate a
  match instead of being rejected.

  I separated these operations:

  - createGame: only callable through the validated lobby start-game sequence.
  - rejoinGame: only succeeds if an active server-side room already exists and the authenticated user belongs to it.
  - Never create a game from the /game WebSocket connection itself.

  The frontend currently stores gameId in local storage and restores it on reload. That value should only be a hint; the server must confirm it. Directly
  opening /game with no confirmed active match currently risks rendering an empty or stale board while sending /joinGame:.

  So the rule is:

  > Users may navigate directly to /game, but they cannot interact with or see the game board until the server confirms an existing game and supplies its
  > authoritative state.
  
<img width="795" height="292" alt="Screenshot 2026-07-24 at 4 55 15 PM" src="https://github.com/user-attachments/assets/f3b18d79-7dbd-4473-97f7-7ae80bcb896b" />


<img width="396" height="153" alt="Screenshot 2026-07-24 at 4 55 05 PM" src="https://github.com/user-attachments/assets/a96ab2da-0337-4e46-973c-14c9156cc12f" />

