### PR TITLE
Create Mute Blocked Users in Lobby Chat

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocket.java
@@ -94,7 +94,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         List<RoomDTO> openRoomsDTO = openRooms.stream().map(this::getRoomDTO).toList();
 
         sendTextMessage(session, "[ROOMS]:" + objectMapper.writeValueAsString(openRoomsDTO));
-        sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
+        sendGlobalChatHistory(session);
         sendTextMessage(session, "[USER_COUNT]:" + getTotalSessionCount());
 
         globalActiveSessions.add(session);
@@ -629,7 +629,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         }
 
         sendTextMessage(session, "[LEAVE_ROOM]");
-        sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
+        sendGlobalChatHistory(session);
         sendTextMessage(session, "[CHAT_MESSAGE]:【SERVER】: You have left the room " + room.getName() + ".");
         broadcastRooms();
     }
@@ -682,7 +682,7 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         sendRoomUpdate(room);
 
         sendTextMessage(player.getSession(), "[KICKED]");
-        sendTextMessage(player.getSession(), "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(globalChatMessages));
+        sendGlobalChatHistory(player.getSession());
         sendTextMessage(player.getSession(), "[CHAT_MESSAGE]:【SERVER】: You have been kicked from the room " + room.getName() + ".");
 
         sendTextMessage(session, "[SUCCESS]");
@@ -707,7 +707,9 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         if (globalChatMessages.size() > 500) globalChatMessages.removeFirst();
 
         for (WebSocketSession webSocketSession : globalActiveSessions) {
-            sendTextMessage(webSocketSession, "[CHAT_MESSAGE]:" + objectMapper.writeValueAsString(chatMessage));
+            if (canReceiveChatMessage(webSocketSession, chatMessage)) {
+                sendTextMessage(webSocketSession, "[CHAT_MESSAGE]:" + objectMapper.writeValueAsString(chatMessage));
+            }
         }
     }
 
@@ -726,8 +728,27 @@ public class LobbyWebSocket extends TextWebSocketHandler {
         ChatMessage chatMessage = new ChatMessage(messageContent, userName);
 
         for (LobbyPlayer player : room.getPlayers()) {
-            sendTextMessage(player.getSession(), "[CHAT_MESSAGE_ROOM]:" + objectMapper.writeValueAsString(chatMessage));
+            if (canReceiveChatMessage(player.getSession(), chatMessage)) {
+                sendTextMessage(player.getSession(), "[CHAT_MESSAGE_ROOM]:" + objectMapper.writeValueAsString(chatMessage));
+            }
         }
+    }
+
+    private void sendGlobalChatHistory(WebSocketSession session) throws IOException {
+        sendTextMessage(session, "[GLOBAL_CHAT]:" + objectMapper.writeValueAsString(getVisibleGlobalChatMessages(session)));
+    }
+
+    List<ChatMessage> getVisibleGlobalChatMessages(WebSocketSession session) {
+        return globalChatMessages.stream()
+                .filter(message -> canReceiveChatMessage(session, message))
+                .toList();
+    }
+
+    private boolean canReceiveChatMessage(WebSocketSession recipient, ChatMessage message) {
+        Principal principal = recipient.getPrincipal();
+        if (principal == null || "【SERVER】".equals(message.author())) return true;
+
+        return !mongoUserDetailsService.getBlockedAccounts(principal.getName()).contains(message.author());
     }
 
     private Room getRoomById(String roomId) {

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocketTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/lobby/LobbyWebSocketTest.java
@@ -1,0 +1,107 @@
+package com.github.wekaito.backend.websocket.lobby;
+
+import com.github.wekaito.backend.models.ChatMessage;
+import com.github.wekaito.backend.security.MongoUserDetailsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Proxy;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LobbyWebSocketTest {
+
+    private MongoUserDetailsService userDetailsService;
+    private LobbyWebSocket lobbyWebSocket;
+
+    @BeforeEach
+    void setUp() {
+        userDetailsService = mock(MongoUserDetailsService.class);
+        lobbyWebSocket = new LobbyWebSocket(userDetailsService, null, null);
+    }
+
+    @Test
+    void blockedAuthorsAreMutedForTheBlockingUserOnly() throws Exception {
+        TestSession author = new TestSession("blocked-user");
+        TestSession blocker = new TestSession("blocking-user");
+        TestSession otherUser = new TestSession("other-user");
+        when(userDetailsService.getBlockedAccounts("blocking-user")).thenReturn(List.of("blocked-user"));
+        when(userDetailsService.getBlockedAccounts("blocked-user")).thenReturn(List.of());
+        when(userDetailsService.getBlockedAccounts("other-user")).thenReturn(List.of());
+        lobbyWebSocket.getGlobalActiveSessions().addAll(
+                List.of(author.session(), blocker.session(), otherUser.session())
+        );
+
+        lobbyWebSocket.handleTextMessage(author.session(), new TextMessage("/chatMessage:hidden message"));
+
+        assertFalse(hasChatMessage(blocker, "hidden message"));
+        assertTrue(hasChatMessage(author, "hidden message"));
+        assertTrue(hasChatMessage(otherUser, "hidden message"));
+    }
+
+    @Test
+    void blockedAuthorsAreRemovedFromChatHistoryButServerMessagesRemain() {
+        TestSession blocker = new TestSession("blocking-user");
+        when(userDetailsService.getBlockedAccounts("blocking-user")).thenReturn(List.of("blocked-user"));
+        lobbyWebSocket.getGlobalChatMessages().clear();
+        lobbyWebSocket.getGlobalChatMessages().add(new ChatMessage("hidden message", "blocked-user"));
+        lobbyWebSocket.getGlobalChatMessages().add(new ChatMessage("visible message", "other-user"));
+        lobbyWebSocket.getGlobalChatMessages().add(new ChatMessage("server message", "【SERVER】"));
+
+        List<ChatMessage> visibleMessages = lobbyWebSocket.getVisibleGlobalChatMessages(blocker.session());
+
+        assertEquals(2, visibleMessages.size());
+        assertFalse(visibleMessages.stream().anyMatch(message -> message.author().equals("blocked-user")));
+        assertTrue(visibleMessages.stream().anyMatch(message -> message.author().equals("other-user")));
+        assertTrue(visibleMessages.stream().anyMatch(message -> message.author().equals("【SERVER】")));
+    }
+
+    private boolean hasChatMessage(TestSession session, String message) {
+        return session.messages().stream()
+                .anyMatch(payload -> payload.startsWith("[CHAT_MESSAGE]:") && payload.contains(message));
+    }
+
+    private record TestSession(WebSocketSession session, List<String> messages) {
+        TestSession(String username) {
+            this(createSession(username));
+        }
+
+        private TestSession(SessionFixture fixture) {
+            this(fixture.session(), fixture.messages());
+        }
+
+        private static SessionFixture createSession(String username) {
+            List<String> messages = new ArrayList<>();
+            Principal principal = () -> username;
+            WebSocketSession session = (WebSocketSession) Proxy.newProxyInstance(
+                    WebSocketSession.class.getClassLoader(),
+                    new Class<?>[]{WebSocketSession.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "getPrincipal" -> principal;
+                        case "isOpen" -> true;
+                        case "sendMessage" -> {
+                            WebSocketMessage<?> message = (WebSocketMessage<?>) args[0];
+                            messages.add(message.getPayload().toString());
+                            yield null;
+                        }
+                        case "hashCode" -> System.identityHashCode(proxy);
+                        case "equals" -> proxy == args[0];
+                        default -> null;
+                    }
+            );
+            return new SessionFixture(session, messages);
+        }
+    }
+
+    private record SessionFixture(WebSocketSession session, List<String> messages) {}
+}

--- a/frontend/src/components/profile/BlockedUsers.test.tsx
+++ b/frontend/src/components/profile/BlockedUsers.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGeneralStates } from "../../hooks/useGeneralStates.ts";
+import BlockedUsers from "./BlockedUsers.tsx";
+
+vi.mock("axios");
+
+describe("BlockedUsers", () => {
+    beforeEach(() => {
+        vi.mocked(axios.get).mockResolvedValue({ data: [] });
+        useGeneralStates.setState({ user: "CurrentUser" });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it("disables Add when own username is entered", async () => {
+        const user = userEvent.setup();
+        render(<BlockedUsers />);
+
+        const input = screen.getByPlaceholderText("Enter username to block");
+        const addButton = screen.getByRole("button", { name: "ADD" });
+
+        await user.type(input, " currentuser ");
+
+        expect(addButton).toBeDisabled();
+        expect(axios.post).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/profile/BlockedUsers.tsx
+++ b/frontend/src/components/profile/BlockedUsers.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, FormEvent } from "react";
 import axios from "axios";
 import { Button } from "../Button.tsx";
 import { notifyError } from "../../utils/toasts.ts";
+import { useGeneralStates } from "../../hooks/useGeneralStates.ts";
 
 export default function BlockedUsers() {
+    const user = useGeneralStates((state) => state.user);
     const [newUsername, setNewUsername] = useState("");
     const [blockedUsers, setBlockedUsers] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
@@ -53,7 +55,7 @@ export default function BlockedUsers() {
         event.preventDefault();
         const trimmedUsername = newUsername.trim();
 
-        if (!trimmedUsername) return;
+        if (!trimmedUsername || trimmedUsername.toLowerCase() === user.toLowerCase()) return;
 
         if (blockedUsers.includes(trimmedUsername)) {
             alert("User is already blocked");
@@ -64,6 +66,8 @@ export default function BlockedUsers() {
         addBlockedUser(trimmedUsername);
         setNewUsername("");
     };
+
+    const isOwnUsername = newUsername.trim().toLowerCase() === user.toLowerCase();
 
     const handleRemoveUser = (usernameToRemove: string) => {
         removeBlockedUser(usernameToRemove);
@@ -82,7 +86,12 @@ export default function BlockedUsers() {
                     />
                     <Button
                         type="submit"
-                        disabled={loading || !newUsername.trim() || blockedUsers.includes(newUsername.trim())}
+                        disabled={
+                            loading ||
+                            !newUsername.trim() ||
+                            isOwnUsername ||
+                            blockedUsers.includes(newUsername.trim())
+                        }
                     >
                         ADD
                     </Button>


### PR DESCRIPTION
## Summary

  - Mute blocked users in global lobby and private room chats.
  - Remove blocked users’ messages from restored chat history.
  - Keep server messages visible.
  - Disable profile ADD button when entering own username.
  - Reject self-block attempts at controller and service layers.

  ## Testing

  - Added lobby message filtering tests.
  - Added frontend self-block button test.
  - Added controller and service self-block tests.
  - Focused frontend and backend tests pass.