### PR TITLE
Prevent Rematches After Surrender

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -98,6 +98,19 @@ public class GameWebSocket extends TextWebSocketHandler {
             return;
         }
 
+        if (roomMessage.equals("/surrender")) {
+            gameRoom.setEndedBySurrender(true);
+            gameRoom.sendMessageToOtherSessions(session, "[SURRENDER]");
+            return;
+        }
+
+        if (gameRoom.isEndedBySurrender() &&
+                (roomMessage.startsWith("/restartRequest") ||
+                        roomMessage.equals("/acceptRestart") ||
+                        roomMessage.startsWith("/restartGame:"))) {
+            return;
+        }
+
         if (roomMessage.startsWith("/restartGame:")) {
             boolean isThisPlayerStarting = roomMessage.split(":")[1].equals("first");
             String username = Objects.requireNonNull(session.getPrincipal()).getName();
@@ -204,7 +217,6 @@ public class GameWebSocket extends TextWebSocketHandler {
     /* These actions do not alter the board state, therefore do not need a separate handler */
     private String convertCommand(String command) {
         return switch (command) {
-            case "/surrender" -> "[SURRENDER]";
             case "/restartRequestAsFirst" -> "[RESTART_AS_FIRST]";
             case "/restartRequestAsSecond" -> "[RESTART_AS_SECOND]";
             case "/acceptRestart" -> "[ACCEPT_RESTART]";

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameRoom.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/GameRoom.java
@@ -45,6 +45,7 @@ public class GameRoom {
 
     private BoardState boardState = null;
     private String[] chat;
+    private boolean endedBySurrender;
     private Phase phase = Phase.BREEDING;
     private String usernameTurn;
     int bootStage = 0; // 0 = CLEAR, 1 = SHOW_STARTING_PLAYER, 2 = MULLIGAN, 3 = MULLIGAN, 4 = GAME_START

--- a/frontend/src/components/game/ModalDialog/SurrenderModal.tsx
+++ b/frontend/src/components/game/ModalDialog/SurrenderModal.tsx
@@ -16,9 +16,13 @@ export default function SurrenderModal({ setSurrenderModal, wsUtils }: Props) {
 
     const setIsEndDialogOpen = useGameUIStates((state) => state.setIsEndDialogOpen);
     const setEndDialogText = useGameUIStates((state) => state.setEndDialogText);
+    const setEndedBySurrender = useGameUIStates((state) => state.setEndedBySurrender);
+    const setRestartPromptModal = useGameUIStates((state) => state.setRestartPromptModal);
 
     function handleSurrender() {
         setSurrenderModal(false);
+        setRestartPromptModal(false);
+        setEndedBySurrender(true);
         setIsEndDialogOpen(true);
         setEndDialogText("🏳️ You surrendered.");
         sendMessage(`${gameId}:/surrender`);

--- a/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
+++ b/frontend/src/components/game/OpponentBoardSide/OpponentBoardSide.tsx
@@ -17,9 +17,11 @@ import RestartRequestModal from "../ModalDialog/RestartRequestModal.tsx";
 import SurrenderModal from "../ModalDialog/SurrenderModal.tsx";
 import { useState } from "react";
 import { useGeneralStates } from "../../../hooks/useGeneralStates.ts";
+import { useGameUIStates } from "../../../hooks/useGameUIStates.ts";
 
 export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
     const iconWidth = useGeneralStates((state) => state.cardWidth * 0.45);
+    const endedBySurrender = useGameUIStates((state) => state.endedBySurrender);
 
     const [restartRequestModal, setRestartRequestModal] = useState<boolean>(false);
     const [surrenderModal, setSurrenderModal] = useState<boolean>(false);
@@ -43,10 +45,17 @@ export default function OpponentBoardSide({ wsUtils }: { wsUtils?: WSUtils }) {
                     </PanelButton>
                     <PanelButton
                         className={"button"}
-                        onClick={() => setRestartRequestModal(true)}
+                        aria-disabled={endedBySurrender}
+                        onClick={() => {
+                            if (!endedBySurrender) setRestartRequestModal(true);
+                        }}
+                        $disabled={endedBySurrender}
                         style={{ gridArea: "restart", transform: `translate(-4px, -${iconWidth / 5}px)` }}
                     >
-                        <RestartIcon className={"button"} sx={{ fontSize: iconWidth - 5, color: "mediumaquamarine" }} />
+                        <RestartIcon
+                            className={"button"}
+                            sx={{ fontSize: iconWidth - 5, color: endedBySurrender ? "grey" : "mediumaquamarine" }}
+                        />
                     </PanelButton>
                 </>
             )}
@@ -95,7 +104,7 @@ const OpponentFieldNavigationContainer = styled.div`
     padding: 2px;
 `;
 
-const PanelButton = styled.div`
+const PanelButton = styled.div<{ $disabled?: boolean }>`
     width: 100%;
     height: 80%;
     background: rgba(12, 21, 16, 0.25);
@@ -108,8 +117,11 @@ const PanelButton = styled.div`
     justify-content: center;
     align-items: center;
     z-index: 1;
+    cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+    opacity: ${({ $disabled }) => ($disabled ? 0.45 : 1)};
 
     &:hover {
-        background: rgba(26, 179, 201, 0.35);
+        background: ${({ $disabled }) =>
+            $disabled ? "rgba(12, 21, 16, 0.25)" : "rgba(26, 179, 201, 0.35)"};
     }
 `;

--- a/frontend/src/hooks/useGameUIStates.ts
+++ b/frontend/src/hooks/useGameUIStates.ts
@@ -35,6 +35,9 @@ type State = {
     isRematch: boolean;
     setIsRematch: (isRematch: boolean) => void;
 
+    endedBySurrender: boolean;
+    setEndedBySurrender: (endedBySurrender: boolean) => void;
+
     isEndDialogOpen: boolean; // TODO: Refactor to one dialog state like openedCardDialog, to avoid multiple dialogs
     setIsEndDialogOpen: (open: boolean) => void;
 
@@ -99,6 +102,9 @@ export const useGameUIStates = create<State>((set) => ({
 
     isRematch: false,
     setIsRematch: (isRematch) => set({ isRematch }),
+
+    endedBySurrender: false,
+    setEndedBySurrender: (endedBySurrender) => set({ endedBySurrender }),
 
     isEndDialogOpen: false,
     setIsEndDialogOpen: (open) => set({ isEndDialogOpen: open }),

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -52,6 +52,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
     const setRestartPromptModal = useGameUIStates((state) => state.setRestartPromptModal);
     const isRematch = useGameUIStates((state) => state.isRematch);
     const setIsRematch = useGameUIStates((state) => state.setIsRematch);
+    const setEndedBySurrender = useGameUIStates((state) => state.setEndedBySurrender);
     const setIsEndDialogOpen = useGameUIStates((state) => state.setIsEndDialogOpen);
     const setEndDialogText = useGameUIStates((state) => state.setEndDialogText);
     const setOpponentEmote = useGameUIStates((state) => state.setOpponentEmote);
@@ -122,6 +123,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
 
         onMessage: (event) => {
             if (event.data === "[START_GAME]") {
+                setEndedBySurrender(false);
                 setStartingPlayer("");
                 setMyAttackPhase(false);
                 setOpponentAttackPhase(false);
@@ -388,6 +390,8 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                     break;
                 }
                 case "[SURRENDER]": {
+                    setEndedBySurrender(true);
+                    setRestartPromptModal(false);
                     setIsEndDialogOpen(true);
                     setEndDialogText("🎉 Your opponent surrendered!");
                     break;


### PR DESCRIPTION
## Summary
Addresses: https://github.com/WE-Kaito/digimon-tcg-simulator/issues/339

 Prevents rematches after a game ends through surrender and fixes a game-page mounting crash.

  - Tracks when a game has ended by surrender.
  - Disables and greys out the rematch button for both players.
  - Closes any open rematch prompt after surrender.
  - Blocks rematch request, acceptance, and restart WebSocket commands on the backend.
  - Resets surrender state when a new game starts.
  - Fixes the GamePage layout effect returning an invalid cleanup value, which caused TypeError: destroy is not a function.

After a player surrenders, we should see that the rematch button gets greyed out.

<img width="380" height="134" alt="Screenshot 2026-07-28 at 2 20 49 PM" src="https://github.com/user-attachments/assets/e974da8a-bdc1-4019-b647-660791a4307d" />

