### PR TITLE
Reworked Effect Targeting

### DIFF
--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -240,16 +240,26 @@ public class GameWebSocket extends TextWebSocketHandler {
                 rejectEffectTarget(gameRoom, session);
                 return;
             }
+            GameCard effectSourceCard = null;
+            if (!isBlank(payload.effectSourceCardId())) {
+                effectSourceCard = findCardInField(boardState, sourceField, payload.effectSourceCardId());
+                if (effectSourceCard == null) {
+                    rejectEffectTarget(gameRoom, session);
+                    return;
+                }
+            }
 
             EffectTargetEvent event = new EffectTargetEvent(
                     username,
                     payload.sourceCardId(),
+                    payload.effectSourceCardId(),
                     payload.targetCardId(),
                     payload.sourceLocation(),
                     payload.targetLocation(),
                     getFieldOwner(sourceField, gameRoom),
                     getFieldOwner(targetField, gameRoom),
                     sourceCard.getName(),
+                    effectSourceCard == null ? null : effectSourceCard.getName(),
                     targetCard.getName(),
                     payload.timing().trim(),
                     payload.effectText().trim()
@@ -282,6 +292,9 @@ public class GameWebSocket extends TextWebSocketHandler {
         try {
             UUID.fromString(payload.sourceCardId());
             UUID.fromString(payload.targetCardId());
+            if (!isBlank(payload.effectSourceCardId())) {
+                UUID.fromString(payload.effectSourceCardId());
+            }
             return true;
         } catch (IllegalArgumentException ignored) {
             return false;

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/GameWebSocket.java
@@ -44,6 +44,8 @@ public class GameWebSocket extends TextWebSocketHandler {
         "player1Hand", "player1Deck", "player1EggDeck", "player1Trash", "player1Security", "player1BreedingArea",
         "player2Hand", "player2Deck", "player2EggDeck", "player2Trash", "player2Security", "player2BreedingArea"
     );
+    private static final int MAX_EFFECT_TIMING_LENGTH = 80;
+    private static final int MAX_EFFECT_TEXT_LENGTH = 2000;
 
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
@@ -154,6 +156,11 @@ public class GameWebSocket extends TextWebSocketHandler {
             return;
         }
 
+        if (roomMessage.startsWith("/effectTarget:")) {
+            handleEffectTarget(gameRoom, session, roomMessage);
+            return;
+        }
+
         if (roomMessage.startsWith("/createToken:")) {
             handleCreateToken(gameRoom, session, roomMessage);
             return;
@@ -199,6 +206,126 @@ public class GameWebSocket extends TextWebSocketHandler {
             newChat[currentChat.length] = message;
             gameRoom.setChat(newChat);
         }
+    }
+
+    private void handleEffectTarget(GameRoom gameRoom, WebSocketSession session, String roomMessage) {
+        try {
+            EffectTargetPayload payload = objectMapper.readValue(
+                    roomMessage.substring("/effectTarget:".length()),
+                    EffectTargetPayload.class
+            );
+            String username = Objects.requireNonNull(session.getPrincipal()).getName();
+
+            if (!isValidEffectTargetPayload(payload)) {
+                rejectEffectTarget(gameRoom, session);
+                return;
+            }
+
+            BoardState boardState = gameRoom.getBoardState();
+            if (boardState == null) {
+                rejectEffectTarget(gameRoom, session);
+                return;
+            }
+
+            String sourceField = mapEffectLocationToServer(payload.sourceLocation(), username, gameRoom);
+            String targetField = mapEffectLocationToServer(payload.targetLocation(), username, gameRoom);
+            if (!boardState.hasField(sourceField) || !boardState.hasField(targetField)) {
+                rejectEffectTarget(gameRoom, session);
+                return;
+            }
+
+            GameCard sourceCard = findCardInField(boardState, sourceField, payload.sourceCardId());
+            GameCard targetCard = findCardInField(boardState, targetField, payload.targetCardId());
+            if (sourceCard == null || targetCard == null) {
+                rejectEffectTarget(gameRoom, session);
+                return;
+            }
+
+            EffectTargetEvent event = new EffectTargetEvent(
+                    username,
+                    payload.sourceCardId(),
+                    payload.targetCardId(),
+                    payload.sourceLocation(),
+                    payload.targetLocation(),
+                    getFieldOwner(sourceField, gameRoom),
+                    getFieldOwner(targetField, gameRoom),
+                    sourceCard.getName(),
+                    targetCard.getName(),
+                    payload.timing().trim(),
+                    payload.effectText().trim()
+            );
+            String eventJson = objectMapper.writeValueAsString(event);
+
+            storeChatMessage(gameRoom, username + "﹕[EFFECT_TARGET]≔" + eventJson);
+            gameRoom.sendMessagesToAll("[EFFECT_TARGET]:" + eventJson);
+        } catch (Exception ignored) {
+            rejectEffectTarget(gameRoom, session);
+        }
+    }
+
+    private boolean isValidEffectTargetPayload(EffectTargetPayload payload) {
+        if (payload == null ||
+                isBlank(payload.sourceCardId()) ||
+                isBlank(payload.targetCardId()) ||
+                isBlank(payload.sourceLocation()) ||
+                isBlank(payload.targetLocation()) ||
+                isBlank(payload.timing()) ||
+                isBlank(payload.effectText())) {
+            return false;
+        }
+        if (payload.timing().length() > MAX_EFFECT_TIMING_LENGTH ||
+                payload.effectText().length() > MAX_EFFECT_TEXT_LENGTH ||
+                !isOwnEffectField(payload.sourceLocation()) ||
+                !isEffectField(payload.targetLocation())) {
+            return false;
+        }
+        try {
+            UUID.fromString(payload.sourceCardId());
+            UUID.fromString(payload.targetCardId());
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private boolean isOwnEffectField(String location) {
+        return location.equals("myBreedingArea") || location.matches("myDigi(?:[1-9]|1\\d|2[01])");
+    }
+
+    private boolean isEffectField(String location) {
+        return location.matches("(?:my|opponent)Digi(?:[1-9]|1\\d|2[01])") ||
+                location.matches("(?:my|opponent)BreedingArea");
+    }
+
+    private String mapEffectLocationToServer(String location, String username, GameRoom gameRoom) {
+        boolean senderIsPlayer1 = gameRoom.getPlayer1().username().equals(username);
+        boolean senderSide = location.startsWith("my");
+        int playerNumber = senderSide == senderIsPlayer1 ? 1 : 2;
+        String suffix = location.startsWith("opponent")
+                ? location.substring("opponent".length())
+                : location.substring("my".length());
+        return "player" + playerNumber + suffix;
+    }
+
+    private GameCard findCardInField(BoardState boardState, String field, String cardId) {
+        return boardState.getFieldByName(field).stream()
+                .filter(card -> card.getId() != null && card.getId().toString().equals(cardId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String getFieldOwner(String field, GameRoom gameRoom) {
+        return field.startsWith("player1")
+                ? gameRoom.getPlayer1().username()
+                : gameRoom.getPlayer2().username();
+    }
+
+    private void rejectEffectTarget(GameRoom gameRoom, WebSocketSession session) {
+        gameRoom.sendMessage(session, "[COMMAND_REJECTED]:effectTarget");
     }
 
     /* These actions do not alter the board state, therefore do not need a separate handler */

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetEvent.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetEvent.java
@@ -3,12 +3,14 @@ package com.github.wekaito.backend.websocket.game.models;
 public record EffectTargetEvent(
         String sender,
         String sourceCardId,
+        String effectSourceCardId,
         String targetCardId,
         String sourceLocation,
         String targetLocation,
         String sourceOwner,
         String targetOwner,
         String sourceName,
+        String effectSourceName,
         String targetName,
         String timing,
         String effectText

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetEvent.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetEvent.java
@@ -1,0 +1,16 @@
+package com.github.wekaito.backend.websocket.game.models;
+
+public record EffectTargetEvent(
+        String sender,
+        String sourceCardId,
+        String targetCardId,
+        String sourceLocation,
+        String targetLocation,
+        String sourceOwner,
+        String targetOwner,
+        String sourceName,
+        String targetName,
+        String timing,
+        String effectText
+) {
+}

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetPayload.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetPayload.java
@@ -1,0 +1,11 @@
+package com.github.wekaito.backend.websocket.game.models;
+
+public record EffectTargetPayload(
+        String sourceCardId,
+        String targetCardId,
+        String sourceLocation,
+        String targetLocation,
+        String timing,
+        String effectText
+) {
+}

--- a/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetPayload.java
+++ b/backend/src/main/java/com/github/wekaito/backend/websocket/game/models/EffectTargetPayload.java
@@ -2,6 +2,7 @@ package com.github.wekaito.backend.websocket.game.models;
 
 public record EffectTargetPayload(
         String sourceCardId,
+        String effectSourceCardId,
         String targetCardId,
         String sourceLocation,
         String targetLocation,

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketEffectTargetTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketEffectTargetTest.java
@@ -32,6 +32,7 @@ class GameWebSocketEffectTargetTest {
     private List<String> player1Messages;
     private List<String> player2Messages;
     private GameCard sourceCard;
+    private GameCard effectSourceCard;
     private GameCard targetCard;
 
     @BeforeEach
@@ -48,9 +49,10 @@ class GameWebSocketEffectTargetTest {
         );
 
         sourceCard = gameCard("Source Digimon");
+        effectSourceCard = gameCard("Inherited Digimon");
         targetCard = gameCard("Target Digimon");
         BoardState boardState = new BoardState();
-        boardState.setPlayer1Digi1(List.of(sourceCard));
+        boardState.setPlayer1Digi1(List.of(effectSourceCard, sourceCard));
         boardState.setPlayer2Digi2(List.of(targetCard));
         gameRoom.setBoardState(boardState);
 
@@ -69,6 +71,7 @@ class GameWebSocketEffectTargetTest {
     void broadcastsValidatedEffectTargetAndStoresStructuredHistory() throws Exception {
         EffectTargetPayload payload = new EffectTargetPayload(
                 sourceCard.getId().toString(),
+                null,
                 targetCard.getId().toString(),
                 "myDigi1",
                 "opponentDigi2",
@@ -94,9 +97,53 @@ class GameWebSocketEffectTargetTest {
     }
 
     @Test
+    void derivesTheEffectSourceNameFromTheValidatedSourceStack() throws Exception {
+        EffectTargetPayload payload = new EffectTargetPayload(
+                sourceCard.getId().toString(),
+                effectSourceCard.getId().toString(),
+                targetCard.getId().toString(),
+                "myDigi1",
+                "opponentDigi2",
+                "Your Turn",
+                "When this Digimon attacks, you may unsuspend it."
+        );
+
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:" + OBJECT_MAPPER.writeValueAsString(payload))
+        );
+
+        assertThat(player1Messages).singleElement().satisfies(message -> assertThat(message)
+                .contains("\"effectSourceCardId\":\"" + effectSourceCard.getId() + "\"")
+                .contains("\"effectSourceName\":\"Inherited Digimon\""));
+    }
+
+    @Test
+    void rejectsAnEffectSourceCardThatIsNotInTheClaimedSourceStack() throws Exception {
+        EffectTargetPayload payload = new EffectTargetPayload(
+                sourceCard.getId().toString(),
+                UUID.randomUUID().toString(),
+                targetCard.getId().toString(),
+                "myDigi1",
+                "opponentDigi2",
+                "Your Turn",
+                "When this Digimon attacks, you may unsuspend it."
+        );
+
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:" + OBJECT_MAPPER.writeValueAsString(payload))
+        );
+
+        assertThat(player1Messages).containsExactly("[COMMAND_REJECTED]:effectTarget");
+        assertThat(player2Messages).isEmpty();
+    }
+
+    @Test
     void rejectsTargetIdThatDoesNotExistAtClaimedLocation() throws Exception {
         EffectTargetPayload payload = new EffectTargetPayload(
                 sourceCard.getId().toString(),
+                null,
                 UUID.randomUUID().toString(),
                 "myDigi1",
                 "opponentDigi2",
@@ -118,6 +165,7 @@ class GameWebSocketEffectTargetTest {
     void rejectsSourceCardClaimedAtTheWrongLocation() throws Exception {
         EffectTargetPayload payload = new EffectTargetPayload(
                 sourceCard.getId().toString(),
+                null,
                 targetCard.getId().toString(),
                 "myDigi2",
                 "opponentDigi2",

--- a/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketEffectTargetTest.java
+++ b/backend/src/test/java/com/github/wekaito/backend/websocket/game/GameWebSocketEffectTargetTest.java
@@ -1,0 +1,194 @@
+package com.github.wekaito.backend.websocket.game;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.wekaito.backend.websocket.game.models.BoardState;
+import com.github.wekaito.backend.websocket.game.models.EffectTargetPayload;
+import com.github.wekaito.backend.websocket.game.models.GameCard;
+import com.github.wekaito.backend.websocket.game.models.GameRoom;
+import com.github.wekaito.backend.websocket.game.models.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.lang.reflect.Proxy;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameWebSocketEffectTargetTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String ROOM_ID = "player1‗player2";
+
+    private GameWebSocket gameWebSocket;
+    private GameRoom gameRoom;
+    private WebSocketSession player1Session;
+    private WebSocketSession player2Session;
+    private List<String> player1Messages;
+    private List<String> player2Messages;
+    private GameCard sourceCard;
+    private GameCard targetCard;
+
+    @BeforeEach
+    void setUp() {
+        gameWebSocket = new GameWebSocket(null, null, null);
+        gameRoom = new GameRoom(
+                ROOM_ID,
+                new Player("player1", "", "", ""),
+                List.of(),
+                List.of(),
+                new Player("player2", "", "", ""),
+                List.of(),
+                List.of()
+        );
+
+        sourceCard = gameCard("Source Digimon");
+        targetCard = gameCard("Target Digimon");
+        BoardState boardState = new BoardState();
+        boardState.setPlayer1Digi1(List.of(sourceCard));
+        boardState.setPlayer2Digi2(List.of(targetCard));
+        gameRoom.setBoardState(boardState);
+
+        TestSession player1 = session("player1", "session-1");
+        TestSession player2 = session("player2", "session-2");
+        player1Session = player1.session();
+        player2Session = player2.session();
+        player1Messages = player1.messages();
+        player2Messages = player2.messages();
+        gameRoom.addSession(player1Session);
+        gameRoom.addSession(player2Session);
+        gameWebSocket.getGameRooms().put(ROOM_ID, gameRoom);
+    }
+
+    @Test
+    void broadcastsValidatedEffectTargetAndStoresStructuredHistory() throws Exception {
+        EffectTargetPayload payload = new EffectTargetPayload(
+                sourceCard.getId().toString(),
+                targetCard.getId().toString(),
+                "myDigi1",
+                "opponentDigi2",
+                "On Play",
+                "Delete 1 of your opponent's Digimon."
+        );
+
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:" + OBJECT_MAPPER.writeValueAsString(payload))
+        );
+
+        assertThat(player1Messages).singleElement().satisfies(message -> assertThat(message)
+                .startsWith("[EFFECT_TARGET]:")
+                .contains("\"sourceOwner\":\"player1\"")
+                .contains("\"targetOwner\":\"player2\"")
+                .contains("\"sourceName\":\"Source Digimon\"")
+                .contains("\"targetName\":\"Target Digimon\""));
+        assertThat(player2Messages).hasSize(1);
+        assertThat(player2Messages.get(0)).startsWith("[EFFECT_TARGET]:");
+        assertThat(gameRoom.getChat()).hasSize(1);
+        assertThat(gameRoom.getChat()[0]).startsWith("player1﹕[EFFECT_TARGET]≔");
+    }
+
+    @Test
+    void rejectsTargetIdThatDoesNotExistAtClaimedLocation() throws Exception {
+        EffectTargetPayload payload = new EffectTargetPayload(
+                sourceCard.getId().toString(),
+                UUID.randomUUID().toString(),
+                "myDigi1",
+                "opponentDigi2",
+                "On Play",
+                "Delete 1 of your opponent's Digimon."
+        );
+
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:" + OBJECT_MAPPER.writeValueAsString(payload))
+        );
+
+        assertThat(player1Messages).containsExactly("[COMMAND_REJECTED]:effectTarget");
+        assertThat(player2Messages).noneMatch(message -> message.startsWith("[EFFECT_TARGET]:"));
+        assertThat(gameRoom.getChat()).isNull();
+    }
+
+    @Test
+    void rejectsSourceCardClaimedAtTheWrongLocation() throws Exception {
+        EffectTargetPayload payload = new EffectTargetPayload(
+                sourceCard.getId().toString(),
+                targetCard.getId().toString(),
+                "myDigi2",
+                "opponentDigi2",
+                "On Play",
+                "Delete 1 of your opponent's Digimon."
+        );
+
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:" + OBJECT_MAPPER.writeValueAsString(payload))
+        );
+
+        assertThat(player1Messages).containsExactly("[COMMAND_REJECTED]:effectTarget");
+        assertThat(player2Messages).noneMatch(message -> message.startsWith("[EFFECT_TARGET]:"));
+    }
+
+    @Test
+    void rejectsMalformedPayload() throws Exception {
+        gameWebSocket.handleTextMessage(
+                player1Session,
+                new TextMessage(ROOM_ID + ":/effectTarget:{not-json}")
+        );
+
+        assertThat(player1Messages).containsExactly("[COMMAND_REJECTED]:effectTarget");
+        assertThat(player2Messages).noneMatch(message -> message.startsWith("[EFFECT_TARGET]:"));
+    }
+
+    private GameCard gameCard(String name) {
+        return GameCard.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .isFaceUp(true)
+                .build();
+    }
+
+    private TestSession session(String username, String id) {
+        Principal principal = () -> username;
+        List<String> messages = new ArrayList<>();
+        WebSocketSession session = (WebSocketSession) Proxy.newProxyInstance(
+                WebSocketSession.class.getClassLoader(),
+                new Class<?>[]{WebSocketSession.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getPrincipal" -> principal;
+                    case "getId" -> id;
+                    case "isOpen" -> true;
+                    case "sendMessage" -> {
+                        messages.add(String.valueOf(((WebSocketMessage<?>) args[0]).getPayload()));
+                        yield null;
+                    }
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "getAttributes" -> java.util.Map.of();
+                    case "toString" -> "TestWebSocketSession[" + id + "]";
+                    default -> defaultValue(method.getReturnType());
+                }
+        );
+        return new TestSession(session, messages);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+
+    private record TestSession(WebSocketSession session, List<String> messages) {}
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -339,6 +339,7 @@ export default function Card(props: CardProps) {
             if (isEffectTargetCandidate && wsUtils) {
                 const payload: EffectTargetPayload = {
                     sourceCardId: effectTargeting.sourceCardId,
+                    effectSourceCardId: effectTargeting.effectSourceCardId,
                     targetCardId: card.id,
                     sourceLocation: effectTargeting.sourceLocation,
                     targetLocation: location,

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -229,6 +229,8 @@ export default function Card(props: CardProps) {
     const setStackDragIcon = useGameUIStates((state) => state.setStackDragIcon);
     const stackDraggedLocation = useGameUIStates((state) => state.stackDraggedLocation);
     const setStackDraggedLocation = useGameUIStates((state) => state.setStackDraggedLocation);
+    const effectTargeting = useGameUIStates((state) => state.effectTargeting);
+    const cancelEffectTargeting = useGameUIStates((state) => state.cancelEffectTargeting);
 
     const playSuspendSfx = useSound((state) => state.playSuspendSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
@@ -317,11 +319,25 @@ export default function Card(props: CardProps) {
 
     const inheritedEffects = topCardInfo(locationCards ?? []).split("\n");
     const inheritAllowed = index === locationCards?.length - 1 && locationsWithInheritedInfo.includes(location);
+    const isTopFieldCard = tamerLocations.includes(location)
+        ? index === 0
+        : index === locationCards.length - 1;
+    const isEffectTargetCandidate =
+        Boolean(effectTargeting) &&
+        isTopFieldCard &&
+        !isCardFaceDown &&
+        [...digimonLocations, ...tamerLocations, "myBreedingArea", "opponentBreedingArea"].includes(location);
+    const isEffectSource = effectTargeting?.sourceCardId === card.id;
 
     const linkCardsForLocation = getLinkCardsForLocation(location);
     const linkCardInfo = topCardInfoLink(linkCardsForLocation);
 
     function handleClick(event: React.MouseEvent) {
+        if (effectTargeting) {
+            event.stopPropagation();
+            if (isEffectTargetCandidate) cancelEffectTargeting();
+            return;
+        }
         if ((isCardFaceDown && location === "mySecurity") || (isCardFaceDown && !location.includes("my"))) return;
         event.stopPropagation();
         selectCard(card);
@@ -573,7 +589,18 @@ export default function Card(props: CardProps) {
                             filter: "brightness(0.5) saturate(1.25) hue-rotate(30deg)",
                         }),
                         ...(markedCard === card.id && { outline: "3px solid red" }),
+                        ...(isEffectSource && {
+                            outline: "3px solid #ff1744",
+                            filter: "brightness(1.12) drop-shadow(0 0 8px #ff1744)",
+                        }),
+                        ...(isEffectTargetCandidate &&
+                            isHovered && {
+                                outline: "3px solid #ff5252",
+                                filter: "brightness(1.1) drop-shadow(0 0 7px #ff1744)",
+                            }),
                     }}
+                    data-effect-source={isEffectSource || undefined}
+                    data-effect-target-card={isEffectTargetCandidate || undefined}
                     className={opponentFieldLocations?.includes(location) ? undefined : "custom-hand-cursor"}
                     onClick={handleClick}
                     onTouchStartCapture={() => index !== undefined && isStackDragMode && setStackSliceIndex(index)}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,7 +1,11 @@
 import { BootStage, CardTypeGame } from "../utils/types.ts";
 import styled from "@emotion/styled";
 import { useGeneralStates } from "../hooks/useGeneralStates.ts";
-import { tamerLocations, useGameBoardStates } from "../hooks/useGameBoardStates.ts";
+import {
+    InheritedCardInfo,
+    tamerLocations,
+    useGameBoardStates,
+} from "../hooks/useGameBoardStates.ts";
 import { getNumericModifier, numbersWithModifiers } from "../utils/functions.ts";
 import { CSSProperties, useEffect, useState } from "react";
 import Lottie from "lottie-react";
@@ -139,15 +143,18 @@ const locationsWithInheritedInfo = ["myBreedingArea", "opponentBreedingArea", ..
 
 const locationsWithAdditionalInfo = [...locationsWithInheritedInfo, ...tamerLocations];
 
-function topCardInfo(locationCards: CardTypeGame[]) {
-    if (locationCards.length <= 1) return "";
-    const effectInfo = [""];
-    locationCards.forEach((card, index) => {
-        if (index === locationCards.length - 1 || !card.inheritedEffect || !card.isFaceUp) return;
-        effectInfo.push(card.inheritedEffect);
-    });
-    effectInfo.reverse();
-    return effectInfo.join("\n");
+function topCardInfo(locationCards: CardTypeGame[]): InheritedCardInfo[] {
+    if (locationCards.length <= 1) return [];
+    return locationCards
+        .slice(0, -1)
+        .filter((card) => Boolean(card.inheritedEffect && card.isFaceUp))
+        .map((card) => ({
+            id: card.id,
+            name: card.name,
+            level: card.level,
+            effect: card.inheritedEffect!,
+        }))
+        .reverse();
 }
 
 function topCardInfoLink(locationCards: CardTypeGame[]) {
@@ -318,7 +325,7 @@ export default function Card(props: CardProps) {
     }
     const [hoveredId, setHoveredId] = useState<string>("");
 
-    const inheritedEffects = topCardInfo(locationCards ?? []).split("\n");
+    const inheritedEffects = topCardInfo(locationCards ?? []);
     const inheritAllowed = index === locationCards?.length - 1 && locationsWithInheritedInfo.includes(location);
     const isTopFieldCard = tamerLocations.includes(location)
         ? index === 0
@@ -389,11 +396,11 @@ export default function Card(props: CardProps) {
             setLinkCardInfo([]);
             return;
         }
-        const inhEff = topCardInfo(locationCardsOfSelected).split("\n");
+        const inhEff = topCardInfo(locationCardsOfSelected);
         const inhAll =
             selectedCard.id === locationCardsOfSelected.at(-1)?.id &&
             locationsWithInheritedInfo.includes(selectedCardLocation);
-        if (!inhEff[0].length) setInheritCardInfo([]);
+        if (!inhEff.length) setInheritCardInfo([]);
         else if (inhAll) setInheritCardInfo(inhEff);
 
         const linkInfo = topCardInfoLink(getLinkCardsForLocation(selectedCardLocation));

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -18,6 +18,7 @@ import { OpenedCardDialog, useGameUIStates } from "../hooks/useGameUIStates.ts";
 import { useLongPress } from "../hooks/useLongPress.ts";
 import { useSettingStates } from "../hooks/useSettingStates.ts";
 import { useImageCache } from "../hooks/useImageCache.ts";
+import { EffectTargetPayload } from "../utils/effectTargeting.ts";
 
 const myDigimonLocations = [
     "myDigi1",
@@ -335,7 +336,20 @@ export default function Card(props: CardProps) {
     function handleClick(event: React.MouseEvent) {
         if (effectTargeting) {
             event.stopPropagation();
-            if (isEffectTargetCandidate) cancelEffectTargeting();
+            if (isEffectTargetCandidate && wsUtils) {
+                const payload: EffectTargetPayload = {
+                    sourceCardId: effectTargeting.sourceCardId,
+                    targetCardId: card.id,
+                    sourceLocation: effectTargeting.sourceLocation,
+                    targetLocation: location,
+                    timing: effectTargeting.timing,
+                    effectText: effectTargeting.effectText,
+                };
+                wsUtils.sendMessage(
+                    `${wsUtils.matchInfo.gameId}:/effectTarget:${JSON.stringify(payload)}`
+                );
+                cancelEffectTargeting();
+            }
             return;
         }
         if ((isCardFaceDown && location === "mySecurity") || (isCardFaceDown && !location.includes("my"))) return;

--- a/frontend/src/components/cardDetails/CardDetails.tsx
+++ b/frontend/src/components/cardDetails/CardDetails.tsx
@@ -413,20 +413,24 @@ export default function CardDetails() {
                     <LinkEffectCard linkCardInfo={linkCardInfo} key={`${cardNumber}_linkedEffect`} />
                 )}
 
-                {inheritCardInfo[0]?.length > 0 && (
+                {inheritCardInfo.length > 0 && (
                     <EffectCard
                         variant={EffectVariant.INHERITED_FROM_DIGIVOLUTION_CARDS}
                         key={`${cardNumber}_inherited`}
                     >
                         <Stack gap={1}>
-                            {inheritCardInfo.map(
-                                (text, index) =>
-                                    !!text && (
-                                        <span key={`${cardNumber}_inherited_from_material_${index}`}>
-                                            <HighlightedKeyWords text={text} />
-                                        </span>
-                                    )
-                            )}
+                            {inheritCardInfo.map((source) => (
+                                <InheritedSourceEffect key={source.id}>
+                                    <InheritedSourceIdentifier>
+                                        {source.name}
+                                        {source.level ? ` • Lv.${source.level}` : ""}
+                                    </InheritedSourceIdentifier>
+                                    <HighlightedKeyWords
+                                        text={source.effect}
+                                        effectSourceCardId={source.id}
+                                    />
+                                </InheritedSourceEffect>
+                            ))}
                         </Stack>
                     </EffectCard>
                 )}
@@ -488,6 +492,22 @@ export default function CardDetails() {
         </Wrapper>
     );
 }
+
+const InheritedSourceEffect = styled.div`
+    padding: 7px 8px 8px;
+    border: 1px solid rgba(185, 202, 216, 0.38);
+    border-radius: 4px;
+    background: rgba(8, 18, 30, 0.28);
+    box-shadow: inset 0 0 12px rgba(145, 190, 220, 0.06);
+`;
+
+const InheritedSourceIdentifier = styled.div`
+    margin-bottom: 6px;
+    color: rgba(205, 211, 218, 0.72);
+    font-size: 0.72em;
+    font-weight: 500;
+    letter-spacing: 0.035em;
+`;
 
 const Wrapper = styled.div<{ inGame: boolean }>`
     grid-area: details;

--- a/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
+++ b/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
@@ -11,8 +11,9 @@ import {
     EffectTimingGroup,
     parseEffectTimingGroups,
 } from "../../utils/effectTiming.ts";
+import type { CardTypeGame } from "../../utils/types.ts";
 
-const EMPTY_SOURCE_CARDS: Array<{ id: string }> = [];
+const EMPTY_SOURCE_CARDS: CardTypeGame[] = [];
 
 export default function HighlightedKeyWords({ text }: { text: string }): JSX.Element | JSX.Element[] {
     const location = useLocation();
@@ -28,7 +29,7 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
         (state) =>
             (sourceLocation
                 ? (state[sourceLocation as keyof typeof state] as unknown)
-                : EMPTY_SOURCE_CARDS) as Array<{ id: string }>
+                : EMPTY_SOURCE_CARDS) as CardTypeGame[]
     );
     const sourceIsTamer = tamerLocations.includes(sourceLocation);
     const sourceIsTopCard =
@@ -50,6 +51,12 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
 
     function handleTimingSelection(group: EffectTimingGroup, timing: string) {
         if (!canStartTargeting || !selectedCard) return;
+        const effectSourceCard = sourceCards.find(
+            (card) =>
+                card.id !== selectedCard.id &&
+                card.isFaceUp &&
+                card.inheritedEffect === text
+        );
 
         if (
             effectTargeting?.sourceCardId === selectedCard.id &&
@@ -62,6 +69,7 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
 
         startEffectTargeting({
             sourceCardId: selectedCard.id,
+            effectSourceCardId: effectSourceCard?.id,
             sourceLocation,
             sourceName: selectedCard.name,
             timing,

--- a/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
+++ b/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
@@ -15,7 +15,13 @@ import type { CardTypeGame } from "../../utils/types.ts";
 
 const EMPTY_SOURCE_CARDS: CardTypeGame[] = [];
 
-export default function HighlightedKeyWords({ text }: { text: string }): JSX.Element | JSX.Element[] {
+export default function HighlightedKeyWords({
+    text,
+    effectSourceCardId,
+}: {
+    text: string;
+    effectSourceCardId?: string;
+}): JSX.Element | JSX.Element[] {
     const location = useLocation();
     const selectedCard = useGeneralStates((state) => state.selectedCard);
     const hoverCard = useGeneralStates((state) => state.hoverCard);
@@ -51,12 +57,14 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
 
     function handleTimingSelection(group: EffectTimingGroup, timing: string) {
         if (!canStartTargeting || !selectedCard) return;
-        const effectSourceCard = sourceCards.find(
-            (card) =>
-                card.id !== selectedCard.id &&
-                card.isFaceUp &&
-                card.inheritedEffect === text
-        );
+        const effectSourceCard = effectSourceCardId
+            ? sourceCards.find((card) => card.id === effectSourceCardId && card.isFaceUp)
+            : sourceCards.find(
+                  (card) =>
+                      card.id !== selectedCard.id &&
+                      card.isFaceUp &&
+                      card.inheritedEffect === text
+              );
 
         if (
             effectTargeting?.sourceCardId === selectedCard.id &&

--- a/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
+++ b/frontend/src/components/cardDetails/HighlightedKeyWords.tsx
@@ -2,8 +2,73 @@ import styled from "@emotion/styled";
 import KeywordTooltip from "./KeywordTooltip.tsx";
 import { JSX } from "react";
 import { uid } from "uid";
+import { useLocation } from "react-router-dom";
+import { useGeneralStates } from "../../hooks/useGeneralStates.ts";
+import { tamerLocations, useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
+import { useGameUIStates } from "../../hooks/useGameUIStates.ts";
+import {
+    EFFECT_TIMINGS,
+    EffectTimingGroup,
+    parseEffectTimingGroups,
+} from "../../utils/effectTiming.ts";
+
+const EMPTY_SOURCE_CARDS: Array<{ id: string }> = [];
 
 export default function HighlightedKeyWords({ text }: { text: string }): JSX.Element | JSX.Element[] {
+    const location = useLocation();
+    const selectedCard = useGeneralStates((state) => state.selectedCard);
+    const hoverCard = useGeneralStates((state) => state.hoverCard);
+    const getCardLocationById = useGameBoardStates((state) => state.getCardLocationById);
+    const effectTargeting = useGameUIStates((state) => state.effectTargeting);
+    const startEffectTargeting = useGameUIStates((state) => state.startEffectTargeting);
+    const cancelEffectTargeting = useGameUIStates((state) => state.cancelEffectTargeting);
+
+    const sourceLocation = getCardLocationById(selectedCard?.id ?? "");
+    const sourceCards = useGameBoardStates(
+        (state) =>
+            (sourceLocation
+                ? (state[sourceLocation as keyof typeof state] as unknown)
+                : EMPTY_SOURCE_CARDS) as Array<{ id: string }>
+    );
+    const sourceIsTamer = tamerLocations.includes(sourceLocation);
+    const sourceIsTopCard =
+        selectedCard?.id === (sourceIsTamer ? sourceCards.at(0)?.id : sourceCards.at(-1)?.id);
+    const sourceIsFaceUp = Boolean(selectedCard && "isFaceUp" in selectedCard && selectedCard.isFaceUp);
+    const sourceIsOnMyField = sourceLocation === "myBreedingArea" || /^myDigi(?:[1-9]|1\d|2[01])$/.test(sourceLocation);
+    const detailsMatchSelection = !hoverCard || hoverCard.id === selectedCard?.id;
+    const canStartTargeting =
+        location.pathname === "/game" &&
+        Boolean(selectedCard) &&
+        sourceIsFaceUp &&
+        sourceIsTopCard &&
+        sourceIsOnMyField &&
+        detailsMatchSelection;
+
+    const effectGroups = parseEffectTimingGroups(text);
+    const timingGroupAt = (index: number) =>
+        effectGroups.find((group) => group.timingTokens.some((token) => token.start === index && token.actionable));
+
+    function handleTimingSelection(group: EffectTimingGroup, timing: string) {
+        if (!canStartTargeting || !selectedCard) return;
+
+        if (
+            effectTargeting?.sourceCardId === selectedCard.id &&
+            effectTargeting.timing === timing &&
+            effectTargeting.effectText === group.effectText
+        ) {
+            cancelEffectTargeting();
+            return;
+        }
+
+        startEffectTargeting({
+            sourceCardId: selectedCard.id,
+            sourceLocation,
+            sourceName: selectedCard.name,
+            timing,
+            effectText: group.effectText,
+        });
+    }
+
     let highlightedText = text;
 
     if (text.startsWith("[DNA Digivolve]"))
@@ -36,6 +101,17 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
             // [keywords]
 
             if (timings.includes(match[2])) {
+                const timingLabel = match[2];
+                const effectGroup = timingGroupAt(match.index);
+                const clickable = Boolean(effectGroup && canStartTargeting);
+                const active =
+                    effectTargeting?.sourceCardId === selectedCard?.id &&
+                    effectTargeting?.timing === timingLabel &&
+                    effectTargeting?.effectText === effectGroup?.effectText;
+                const selectTiming = () => {
+                    if (effectGroup) handleTimingSelection(effectGroup, timingLabel);
+                };
+
                 highlightedParts.push(
                     <HighlightedSquare
                         // workaround for BT19-100
@@ -47,6 +123,30 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
                                 : match[2]
                         }
                         key={id}
+                        $clickable={clickable}
+                        $active={active}
+                        data-effect-timing={clickable ? timingLabel : undefined}
+                        role={clickable ? "button" : undefined}
+                        tabIndex={clickable ? 0 : undefined}
+                        title={clickable ? `Target a card with ${timingLabel}` : undefined}
+                        onClick={
+                            clickable
+                                ? (event) => {
+                                      event.stopPropagation();
+                                      selectTiming();
+                                  }
+                                : undefined
+                        }
+                        onKeyDown={
+                            clickable
+                                ? (event) => {
+                                      if (event.key === "Enter" || event.key === " ") {
+                                          event.preventDefault();
+                                          selectTiming();
+                                      }
+                                  }
+                                : undefined
+                        }
                     >
                         {match[2]}
                     </HighlightedSquare>
@@ -95,7 +195,7 @@ export default function HighlightedKeyWords({ text }: { text: string }): JSX.Ele
     });
 }
 
-const HighlightedSquare = styled.span<{ word: string }>`
+const HighlightedSquare = styled.span<{ word: string; $clickable?: boolean; $active?: boolean }>`
     color: ghostwhite;
     background: ${({ word }) =>
         word === "Hand" || word.includes("Per Turn") || word === "Breeding" || word === "Trash"
@@ -104,6 +204,15 @@ const HighlightedSquare = styled.span<{ word: string }>`
     border-radius: 3px;
     padding: 4px 3px 2px 3px;
     margin-right: 2px;
+    cursor: ${({ $clickable }) => ($clickable ? "crosshair" : "inherit")};
+    outline: ${({ $active }) => ($active ? "2px solid #ff5252" : "none")};
+    outline-offset: 2px;
+    filter: ${({ $active }) => ($active ? "drop-shadow(0 0 4px #ff1744)" : "none")};
+
+    &:hover {
+        filter: ${({ $clickable, $active }) =>
+            $clickable || $active ? "brightness(1.2) drop-shadow(0 0 4px #ff5252)" : "none"};
+    }
 `;
 
 const HighlightedAngle = styled.span`
@@ -174,32 +283,7 @@ const specialEffects = [
 
 const evolutionEffects = ["Digivolve", "App Fusion", "Arts Digivolve"];
 
-const timings = [
-    "On Play",
-    "When Digivolving",
-    "When Attacking",
-    "When Linking",
-    "End of Attack",
-    "On Deletion",
-    "Your Turn",
-    "All Turns",
-    "Opponent's Turn",
-    "End of Opponent's Turn",
-    "Start of Your Turn",
-    "End of Your Turn",
-    "Enf of Opponent's Turn",
-    "Security",
-    "Main",
-    "Start of Your Main Phase",
-    "Start of Opponent's Main Phase",
-    "Once Per Turn",
-    "Twice Per Turn",
-    "Trash",
-    "Hand",
-    "Breeding",
-    "Counter",
-    "End of All Turns",
-];
+const timings: readonly string[] = EFFECT_TIMINGS;
 
 function isTrait(trait: string) {
     switch (trait) {

--- a/frontend/src/components/game/AttackArrows.tsx
+++ b/frontend/src/components/game/AttackArrows.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 // @ts-expect-error cannot find module 'react-arrows', installing dev dependencies didn't help
 import Arrow, { DIRECTION, HEAD } from "react-arrows";
 import { useGameUIStates } from "../../hooks/useGameUIStates.ts";
+import { getSameSideDirection } from "../../utils/effectTargeting.ts";
 
 const opponentBALocations = [
     "opponentDigi1",
@@ -28,6 +29,23 @@ export default function AttackArrows() {
     const isEffectArrow = useGameUIStates((state) => state.isEffectArrow);
 
     const isFromOpponent = opponentBALocations.includes(arrowFrom);
+    const sameSideDirection = isEffectArrow
+        ? getSameSideDirection(arrowFrom, arrowTo)
+        : null;
+    const fromDirection = sameSideDirection
+        ? sameSideDirection === "right"
+            ? DIRECTION.RIGHT
+            : DIRECTION.LEFT
+        : isFromOpponent
+          ? DIRECTION.BOTTOM
+          : DIRECTION.TOP;
+    const toDirection = sameSideDirection
+        ? sameSideDirection === "right"
+            ? DIRECTION.LEFT
+            : DIRECTION.RIGHT
+        : isFromOpponent
+          ? DIRECTION.TOP
+          : DIRECTION.BOTTOM;
 
     if (!arrowFrom || !arrowTo) return <></>;
 
@@ -36,13 +54,19 @@ export default function AttackArrows() {
             isFromOpponent={isFromOpponent}
             isEffect={isEffectArrow}
             from={{
-                direction: isFromOpponent ? DIRECTION.BOTTOM : DIRECTION.TOP,
-                node: () => document.getElementById(arrowFrom),
+                direction: fromDirection,
+                node: () =>
+                    document.getElementById(
+                        sameSideDirection ? `${arrowFrom}-effect-anchor` : arrowFrom
+                    ),
                 translation: [0, 0],
             }}
             to={{
-                direction: isFromOpponent ? DIRECTION.TOP : DIRECTION.BOTTOM,
-                node: () => document.getElementById(arrowTo),
+                direction: toDirection,
+                node: () =>
+                    document.getElementById(
+                        sameSideDirection ? `${arrowTo}-effect-anchor` : arrowTo
+                    ),
                 translation: [0, 0],
             }}
             head={HEAD.NONE}

--- a/frontend/src/components/game/CardStack.test.tsx
+++ b/frontend/src/components/game/CardStack.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { WSUtils } from "../../pages/GamePage.tsx";
+import type { CardTypeGame } from "../../utils/types.ts";
+import CardStack from "./CardStack.tsx";
+
+vi.mock("../Card.tsx", () => ({
+    default: ({ wsUtils }: { wsUtils?: WSUtils }) => (
+        <div data-testid="stack-card" data-has-websocket={Boolean(wsUtils)} />
+    ),
+}));
+
+vi.mock("react-awesome-reveal", () => ({
+    Fade: ({ children }: { children: ReactNode }) => children,
+}));
+
+const card = {
+    id: "target-card",
+    name: "Target Digimon",
+    isFaceUp: true,
+    isTilted: false,
+} as CardTypeGame;
+
+const wsUtils = {
+    matchInfo: { gameId: "player1‗player2", user: "player1", opponentName: "player2" },
+    sendMessage: vi.fn(),
+} as unknown as WSUtils;
+
+describe("CardStack opponent targeting support", () => {
+    afterEach(cleanup);
+
+    it.each(["opponentDigi1", "opponentDigi17"])(
+        "passes WebSocket utilities to an opponent card at %s",
+        (location) => {
+            render(
+                <CardStack
+                    cards={[card]}
+                    location={location}
+                    opponentSide
+                    wsUtils={wsUtils}
+                />
+            );
+
+            expect(screen.getByTestId("stack-card").getAttribute("data-has-websocket")).toBe("true");
+        }
+    );
+});

--- a/frontend/src/components/game/CardStack.tsx
+++ b/frontend/src/components/game/CardStack.tsx
@@ -141,6 +141,7 @@ export default function CardStack(props: CardStackProps) {
                           style={{ width: tamerWidth }}
                           card={card}
                           location={location}
+                          wsUtils={wsUtils}
                           index={index}
                           onContextMenu={(e) =>
                               showOpponentCardMenu?.({
@@ -184,6 +185,7 @@ export default function CardStack(props: CardStackProps) {
                               style={{ width: cardWidth, height: cardWidth * 1.4 }}
                               card={card}
                               location={location}
+                              wsUtils={wsUtils}
                               index={index}
                               onContextMenu={(e) =>
                                   showOpponentCardMenu?.({

--- a/frontend/src/components/game/DigimonField.tsx
+++ b/frontend/src/components/game/DigimonField.tsx
@@ -56,7 +56,8 @@ export default function DigimonField(props: DigimonFieldProps) {
         props: { index: -1, location: "", id: "" },
     });
 
-    const iconSize = useGeneralStates((state) => state.cardWidth / 1.5);
+    const cardWidth = useGeneralStates((state) => state.cardWidth);
+    const iconSize = cardWidth / 1.5;
 
     const [isHoveringOverField, setIsHoveringOverField] = useState(false);
 
@@ -120,6 +121,10 @@ export default function DigimonField(props: DigimonFieldProps) {
             onClick={() => stackOpened && setStackDialog(false)}
             className={stackOpened ? "button" : undefined}
         >
+            <EffectArrowAnchor
+                id={`${location}-effect-anchor`}
+                style={{ width: cardWidth }}
+            />
             {memoizedField}
         </Container>
     );
@@ -150,6 +155,15 @@ const StyledDetailsIcon = styled(DetailsIcon)`
     transform: translate(-50%, -50%);
     opacity: 0.5;
     font-size: 3em;
+`;
+
+const EffectArrowAnchor = styled.div`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    height: 1px;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
 `;
 
 const StyledCloseDetailsIcon = styled(CloseDetailsIcon)`

--- a/frontend/src/components/game/EffectTargetCursor.tsx
+++ b/frontend/src/components/game/EffectTargetCursor.tsx
@@ -1,0 +1,85 @@
+import { Global } from "@emotion/react";
+import styled from "@emotion/styled";
+import ModeStandbyIcon from "@mui/icons-material/ModeStandby";
+import { useEffect, useState } from "react";
+import { useGameUIStates } from "../../hooks/useGameUIStates.ts";
+
+export default function EffectTargetCursor() {
+    const effectTargeting = useGameUIStates((state) => state.effectTargeting);
+    const cancelEffectTargeting = useGameUIStates((state) => state.cancelEffectTargeting);
+    const [position, setPosition] = useState({ x: -100, y: -100 });
+
+    useEffect(() => {
+        if (!effectTargeting) return;
+
+        const handlePointerMove = (event: PointerEvent) => setPosition({ x: event.clientX, y: event.clientY });
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") cancelEffectTargeting();
+        };
+        const handleContextMenu = (event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            cancelEffectTargeting();
+        };
+
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("keydown", handleKeyDown);
+        window.addEventListener("contextmenu", handleContextMenu, true);
+
+        return () => {
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("keydown", handleKeyDown);
+            window.removeEventListener("contextmenu", handleContextMenu, true);
+        };
+    }, [cancelEffectTargeting, effectTargeting]);
+
+    if (!effectTargeting) return null;
+
+    return (
+        <>
+            <Global styles={{ "body, body *": { cursor: "none !important" } }} />
+            <CursorOverlay style={{ transform: `translate(${position.x + 7}px, ${position.y + 7}px)` }}>
+                <ModeStandbyIcon />
+                <Instruction>
+                    Select a target for [{effectTargeting.timing}]
+                    <small>Esc or right-click to cancel</small>
+                </Instruction>
+            </CursorOverlay>
+        </>
+    );
+}
+
+const CursorOverlay = styled.div`
+    position: fixed;
+    inset: 0 auto auto 0;
+    z-index: 100000;
+    pointer-events: none;
+    color: #ff1744;
+    filter: drop-shadow(0 0 2px #000) drop-shadow(0 0 5px rgba(255, 23, 68, 0.9));
+
+    svg {
+        width: 30px;
+        height: 30px;
+    }
+`;
+
+const Instruction = styled.div`
+    position: absolute;
+    top: 32px;
+    left: 18px;
+    width: max-content;
+    max-width: 320px;
+    padding: 5px 8px;
+    border: 1px solid rgba(255, 82, 82, 0.8);
+    border-radius: 4px;
+    background: rgba(10, 12, 20, 0.92);
+    color: #fff1f1;
+    font-family: Cousine, sans-serif;
+    font-size: 12px;
+
+    small {
+        display: block;
+        margin-top: 2px;
+        color: #ffb3bd;
+    }
+`;

--- a/frontend/src/components/game/GameChatLog.tsx
+++ b/frontend/src/components/game/GameChatLog.tsx
@@ -3,7 +3,11 @@ import { useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
 import styled from "@emotion/styled";
 import sendIcon from "../../assets/sendIcon.svg";
 import { WSUtils } from "../../pages/GamePage.tsx";
-import { EffectTargetEvent, formatEffectTargetMessage } from "../../utils/effectTargeting.ts";
+import {
+    EffectTargetEvent,
+    formatEffectTargetMessage,
+    isSameSideEffectTarget,
+} from "../../utils/effectTargeting.ts";
 
 export default function GameChatLog({ matchInfo, sendChatMessage }: Partial<WSUtils>) {
     const messages = useGameBoardStates((state) => state.messages);
@@ -82,7 +86,11 @@ export default function GameChatLog({ matchInfo, sendChatMessage }: Partial<WSUt
                                 chatMessage.substring("[EFFECT_TARGET]≔".length)
                             );
                             return (
-                                <EffectTargetMessage isMyMessage={isMyMessage} key={"msx_" + index}>
+                                <EffectTargetMessage
+                                    isMyMessage={isMyMessage}
+                                    sameSide={isSameSideEffectTarget(effectTargetEvent)}
+                                    key={"msx_" + index}
+                                >
                                     <p>{formatEffectTargetMessage(effectTargetEvent)}</p>
                                 </EffectTargetMessage>
                             );
@@ -148,11 +156,13 @@ const Message = styled.div<{ isMyMessage: boolean }>`
     }
 `;
 
-const EffectTargetMessage = styled(Message)`
+const EffectTargetMessage = styled(Message, {
+    shouldForwardProp: (prop) => prop !== "sameSide",
+})<{ sameSide: boolean }>`
     max-width: 96%;
-    background: rgba(100, 12, 30, 0.42);
-    border-color: rgba(255, 82, 82, 0.8);
-    box-shadow: inset 3px 0 0 #ff1744;
+    background: ${({ sameSide }) => (sameSide ? "rgba(12, 100, 48, 0.42)" : "rgba(100, 12, 30, 0.42)")};
+    border-color: ${({ sameSide }) => (sameSide ? "rgba(76, 220, 120, 0.8)" : "rgba(255, 82, 82, 0.8)")};
+    box-shadow: inset 3px 0 0 ${({ sameSide }) => (sameSide ? "#24c96b" : "#ff1744")};
 `;
 
 const History = styled.div`

--- a/frontend/src/components/game/GameChatLog.tsx
+++ b/frontend/src/components/game/GameChatLog.tsx
@@ -3,6 +3,7 @@ import { useGameBoardStates } from "../../hooks/useGameBoardStates.ts";
 import styled from "@emotion/styled";
 import sendIcon from "../../assets/sendIcon.svg";
 import { WSUtils } from "../../pages/GamePage.tsx";
+import { EffectTargetEvent, formatEffectTargetMessage } from "../../utils/effectTargeting.ts";
 
 export default function GameChatLog({ matchInfo, sendChatMessage }: Partial<WSUtils>) {
     const messages = useGameBoardStates((state) => state.messages);
@@ -75,6 +76,21 @@ export default function GameChatLog({ matchInfo, sendChatMessage }: Partial<WSUt
                         );
                     }
 
+                    if (chatMessage?.startsWith("[EFFECT_TARGET]≔")) {
+                        try {
+                            const effectTargetEvent: EffectTargetEvent = JSON.parse(
+                                chatMessage.substring("[EFFECT_TARGET]≔".length)
+                            );
+                            return (
+                                <EffectTargetMessage isMyMessage={isMyMessage} key={"msx_" + index}>
+                                    <p>{formatEffectTargetMessage(effectTargetEvent)}</p>
+                                </EffectTargetMessage>
+                            );
+                        } catch {
+                            return null;
+                        }
+                    }
+
                     return (
                         <Message isMyMessage={isMyMessage} key={"msx_" + index}>
                             <p>{chatMessage}</p>
@@ -130,6 +146,13 @@ const Message = styled.div<{ isMyMessage: boolean }>`
         max-width: 100%;
         word-break: break-word;
     }
+`;
+
+const EffectTargetMessage = styled(Message)`
+    max-width: 96%;
+    background: rgba(100, 12, 30, 0.42);
+    border-color: rgba(255, 82, 82, 0.8);
+    box-shadow: inset 3px 0 0 #ff1744;
 `;
 
 const History = styled.div`

--- a/frontend/src/hooks/useDeckStates.ts
+++ b/frontend/src/hooks/useDeckStates.ts
@@ -182,7 +182,10 @@ export const useDeckStates = create<State>((set, get) => ({
         axios
             .get("/api/profile/decks")
             .then((res) => res.data)
-            .catch(console.error)
+            .catch((error) => {
+                console.error(error);
+                return [];
+            })
             .then((data) => {
                 set({ decks: data });
             })

--- a/frontend/src/hooks/useGameBoardStates.ts
+++ b/frontend/src/hooks/useGameBoardStates.ts
@@ -192,7 +192,7 @@ export type State = BoardState & {
      * Should be refactored.
      */
     cardToSend: { card: CardTypeGame; location: string } | null;
-    inheritCardInfo: string[];
+    inheritCardInfo: InheritedCardInfo[];
     linkCardInfo: { dp: number; effect: string }[];
     setLinkCardInfo: (linkCardInfo: { dp: number; effect: string }[]) => void;
     getLinkCardsForLocation: (location: string) => CardTypeGame[];
@@ -254,7 +254,7 @@ export type State = BoardState & {
     setCardToSend: (cardToSend: { card: CardTypeGame; location: string } | null) => void;
     setBootStage: (phase: BootStage) => void;
     setGameId: (gameId: string) => void;
-    setInheritCardInfo: (inheritedEffects: string[]) => void;
+    setInheritCardInfo: (inheritedEffects: InheritedCardInfo[]) => void;
     setModifiers: (cardId: string, location: string, modifiers: CardModifiers) => void;
     getCardLocationById: (id: string) => string;
     toggleIsHandHidden: () => void;
@@ -269,6 +269,13 @@ export type State = BoardState & {
 
     markedCard: string;
     setMarkedCard: (cardId: string) => void;
+};
+
+export type InheritedCardInfo = {
+    id: string;
+    name: string;
+    level?: number;
+    effect: string;
 };
 
 const modifierLocations = ["myHand", "myDeckField", "myEggDeck", "myTrash"];

--- a/frontend/src/hooks/useGameUIStates.test.ts
+++ b/frontend/src/hooks/useGameUIStates.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { EffectTargeting, useGameUIStates } from "./useGameUIStates.ts";
+
+const targeting: EffectTargeting = {
+    sourceCardId: "source-1",
+    sourceLocation: "myDigi1",
+    sourceName: "Test Digimon",
+    timing: "On Play",
+    effectText: "Delete 1 of your opponent's Digimon.",
+};
+
+describe("effect targeting state", () => {
+    beforeEach(() => useGameUIStates.setState({ effectTargeting: null }));
+
+    it("starts targeting with a frozen effect snapshot", () => {
+        useGameUIStates.getState().startEffectTargeting(targeting);
+        expect(useGameUIStates.getState().effectTargeting).toEqual(targeting);
+    });
+
+    it("replaces an active effect when another timing is selected", () => {
+        useGameUIStates.getState().startEffectTargeting(targeting);
+        useGameUIStates.getState().startEffectTargeting({ ...targeting, timing: "When Digivolving" });
+        expect(useGameUIStates.getState().effectTargeting?.timing).toBe("When Digivolving");
+    });
+
+    it("cancels targeting", () => {
+        useGameUIStates.getState().startEffectTargeting(targeting);
+        useGameUIStates.getState().cancelEffectTargeting();
+        expect(useGameUIStates.getState().effectTargeting).toBeNull();
+    });
+});

--- a/frontend/src/hooks/useGameUIStates.ts
+++ b/frontend/src/hooks/useGameUIStates.ts
@@ -18,6 +18,7 @@ export enum Emote {
 
 export type EffectTargeting = {
     sourceCardId: string;
+    effectSourceCardId?: string;
     sourceLocation: string;
     sourceName: string;
     timing: string;

--- a/frontend/src/hooks/useGameUIStates.ts
+++ b/frontend/src/hooks/useGameUIStates.ts
@@ -16,6 +16,14 @@ export enum Emote {
     BAFFLED = "baffled",
 }
 
+export type EffectTargeting = {
+    sourceCardId: string;
+    sourceLocation: string;
+    sourceName: string;
+    timing: string;
+    effectText: string;
+};
+
 type State = {
     isStackDragMode: boolean;
     setIsStackDragMode: (isStackDragMode: boolean) => void;
@@ -79,6 +87,10 @@ type State = {
 
     showSecuritySendButtons: boolean;
     setShowSecuritySendButtons: (show: boolean) => void;
+
+    effectTargeting: EffectTargeting | null;
+    startEffectTargeting: (targeting: EffectTargeting) => void;
+    cancelEffectTargeting: () => void;
 };
 
 export const useGameUIStates = create<State>((set) => ({
@@ -144,4 +156,8 @@ export const useGameUIStates = create<State>((set) => ({
 
     showSecuritySendButtons: false,
     setShowSecuritySendButtons: (showSecuritySendButtons) => set({ showSecuritySendButtons }),
+
+    effectTargeting: null,
+    startEffectTargeting: (effectTargeting) => set({ effectTargeting }),
+    cancelEffectTargeting: () => set({ effectTargeting: null }),
 }));

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -6,6 +6,7 @@ import { useGameBoardStates } from "./useGameBoardStates.ts";
 import { useGeneralStates } from "./useGeneralStates.ts";
 import { useSound } from "./useSound.ts";
 import { useGameUIStates } from "./useGameUIStates.ts";
+import { EffectTargetEvent, orientEffectLocation } from "../utils/effectTargeting.ts";
 
 const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 const websocketURL = `${websocketProtocol}//${window.location.host}/api/ws/game`;
@@ -86,6 +87,7 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
     const setArrowTo = useGameUIStates((state) => state.setArrowTo);
     const setIsEffectArrow = useGameUIStates((state) => state.setIsEffectArrow);
     const fieldOffset = useGameUIStates((state) => state.fieldOffset);
+    const opponentFieldOffset = useGameUIStates((state) => state.opponentFieldOffset);
     const setFieldOffset = useGameUIStates((state) => state.setFieldOffset);
     const setOpponentFieldOffset = useGameUIStates((state) => state.setOpponentFieldOffset);
 
@@ -104,6 +106,8 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
     const playTrashCardSfx = useSound((state) => state.playTrashCardSfx);
     const playUnsuspendSfx = useSound((state) => state.playUnsuspendSfx);
     const playRematchSfx = useSound((state) => state.playRematchSfx);
+    const playActivateEffectSfx = useSound((state) => state.playActivateEffectSfx);
+    const playTargetCardSfx = useSound((state) => state.playTargetCardSfx);
 
     function clearCardEffect() {
         const timer = setTimeout(() => setCardIdWithEffect(""), 2600);
@@ -249,6 +253,63 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                 const id = event.data.substring("[ACTIVATE_TARGET]:".length);
                 setCardIdWithTarget(id);
                 clearCardTarget();
+                return;
+            }
+
+            if (event.data.startsWith("[EFFECT_TARGET]:")) {
+                try {
+                    const effectTargetEvent: EffectTargetEvent = JSON.parse(
+                        event.data.substring("[EFFECT_TARGET]:".length)
+                    );
+                    const sourceLocation = orientEffectLocation(
+                        effectTargetEvent.sourceLocation,
+                        effectTargetEvent.sender,
+                        user
+                    );
+                    const targetLocation = orientEffectLocation(
+                        effectTargetEvent.targetLocation,
+                        effectTargetEvent.sender,
+                        user
+                    );
+
+                    setCardIdWithEffect(effectTargetEvent.sourceCardId);
+                    setCardIdWithTarget(effectTargetEvent.targetCardId);
+                    clearCardEffect();
+                    clearCardTarget();
+                    playActivateEffectSfx();
+                    playTargetCardSfx();
+
+                    clearAttackAnimation?.();
+                    setArrowFrom(sourceLocation);
+                    setArrowTo(targetLocation);
+                    setIsEffectArrow(true);
+                    restartAttackAnimation(true);
+
+                    const sourceMatch = sourceLocation.match(/\d+/);
+                    const targetMatch = targetLocation.match(/\d+/);
+                    if (sourceMatch?.[0]) {
+                        const sourceField = Number(sourceMatch[0]);
+                        if (sourceLocation.startsWith("opponent")) {
+                            setOpponentFieldOffset(getValidOffset(sourceField, opponentFieldOffset));
+                        } else {
+                            setFieldOffset(getValidOffset(sourceField, fieldOffset));
+                        }
+                    }
+                    if (targetMatch?.[0]) {
+                        const targetField = Number(targetMatch[0]);
+                        if (targetLocation.startsWith("opponent")) {
+                            setOpponentFieldOffset(getValidOffset(targetField, opponentFieldOffset));
+                        } else {
+                            setFieldOffset(getValidOffset(targetField, fieldOffset));
+                        }
+                    }
+
+                    setMessages(
+                        `${effectTargetEvent.sender}﹕[EFFECT_TARGET]≔${JSON.stringify(effectTargetEvent)}`
+                    );
+                } catch (error) {
+                    console.warn("Failed to parse effect target event:", error);
+                }
                 return;
             }
 

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -6,7 +6,7 @@ import { useGameBoardStates } from "./useGameBoardStates.ts";
 import { useGeneralStates } from "./useGeneralStates.ts";
 import { useSound } from "./useSound.ts";
 import { useGameUIStates } from "./useGameUIStates.ts";
-import { EffectTargetEvent, orientEffectLocation } from "../utils/effectTargeting.ts";
+import { EffectTargetEvent, isSelfEffectTarget, orientEffectLocation } from "../utils/effectTargeting.ts";
 
 const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 const websocketURL = `${websocketProtocol}//${window.location.host}/api/ws/game`;
@@ -280,10 +280,16 @@ export default function useGameWebSocket(props: UseGameWebSocketProps): UseGameW
                     playTargetCardSfx();
 
                     clearAttackAnimation?.();
-                    setArrowFrom(sourceLocation);
-                    setArrowTo(targetLocation);
-                    setIsEffectArrow(true);
-                    restartAttackAnimation(true);
+                    if (isSelfEffectTarget(effectTargetEvent)) {
+                        setArrowFrom("");
+                        setArrowTo("");
+                        setIsEffectArrow(false);
+                    } else {
+                        setArrowFrom(sourceLocation);
+                        setArrowTo(targetLocation);
+                        setIsEffectArrow(true);
+                        restartAttackAnimation(true);
+                    }
 
                     const sourceMatch = sourceLocation.match(/\d+/);
                     const targetMatch = targetLocation.match(/\d+/);

--- a/frontend/src/utils/effectTargeting.test.ts
+++ b/frontend/src/utils/effectTargeting.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+    EffectTargetEvent,
+    flipEffectLocation,
+    formatEffectTargetMessage,
+    orientEffectLocation,
+} from "./effectTargeting.ts";
+
+const event: EffectTargetEvent = {
+    sender: "Test",
+    sourceCardId: "source-id",
+    targetCardId: "target-id",
+    sourceLocation: "myDigi1",
+    targetLocation: "opponentDigi2",
+    sourceOwner: "Test",
+    targetOwner: "Test2",
+    sourceName: "Titamon + SkullBaluchimon",
+    targetName: "ClearAgumon",
+    timing: "On Play",
+    effectText: "Delete all of your opponent's Digimon with the lowest level.",
+};
+
+describe("effect target multiplayer helpers", () => {
+    it("flips sender-relative locations for the opponent", () => {
+        expect(flipEffectLocation("myDigi1")).toBe("opponentDigi1");
+        expect(flipEffectLocation("opponentBreedingArea")).toBe("myBreedingArea");
+    });
+
+    it("keeps locations unchanged for the sender", () => {
+        expect(orientEffectLocation("myDigi1", "Test", "Test")).toBe("myDigi1");
+    });
+
+    it("orients locations for the receiving player", () => {
+        expect(orientEffectLocation("opponentDigi2", "Test", "Test2")).toBe("myDigi2");
+    });
+
+    it("formats the structured event consistently", () => {
+        expect(formatEffectTargetMessage(event)).toBe(
+            "Test's Titamon + SkullBaluchimon is targeting Test2's ClearAgumon with [On Play]: " +
+                "Delete all of your opponent's Digimon with the lowest level."
+        );
+    });
+});

--- a/frontend/src/utils/effectTargeting.test.ts
+++ b/frontend/src/utils/effectTargeting.test.ts
@@ -60,4 +60,18 @@ describe("effect target multiplayer helpers", () => {
                 "Delete all of your opponent's Digimon with the lowest level."
         );
     });
+
+    it("formats a self-targeted effect using itself", () => {
+        expect(
+            formatEffectTargetMessage({
+                ...event,
+                targetCardId: event.sourceCardId,
+                targetOwner: event.sourceOwner,
+                targetName: event.sourceName,
+            })
+        ).toBe(
+            "Test's Titamon + SkullBaluchimon is targeting itself with [On Play]: " +
+                "Delete all of your opponent's Digimon with the lowest level."
+        );
+    });
 });

--- a/frontend/src/utils/effectTargeting.test.ts
+++ b/frontend/src/utils/effectTargeting.test.ts
@@ -74,4 +74,17 @@ describe("effect target multiplayer helpers", () => {
                 "Delete all of your opponent's Digimon with the lowest level."
         );
     });
+
+    it("names the evolution source card supplying an inherited effect", () => {
+        expect(
+            formatEffectTargetMessage({
+                ...event,
+                effectSourceCardId: "inherited-source-id",
+                effectSourceName: "Koromon",
+            })
+        ).toBe(
+            "Test's Titamon + SkullBaluchimon is using Koromon to target Test2's ClearAgumon with [On Play]: " +
+                "Delete all of your opponent's Digimon with the lowest level."
+        );
+    });
 });

--- a/frontend/src/utils/effectTargeting.test.ts
+++ b/frontend/src/utils/effectTargeting.test.ts
@@ -3,6 +3,9 @@ import {
     EffectTargetEvent,
     flipEffectLocation,
     formatEffectTargetMessage,
+    getSameSideDirection,
+    isSameSideEffectTarget,
+    isSelfEffectTarget,
     orientEffectLocation,
 } from "./effectTargeting.ts";
 
@@ -32,6 +35,23 @@ describe("effect target multiplayer helpers", () => {
 
     it("orients locations for the receiving player", () => {
         expect(orientEffectLocation("opponentDigi2", "Test", "Test2")).toBe("myDigi2");
+    });
+
+    it("identifies an effect applied to its own source card", () => {
+        expect(isSelfEffectTarget({ ...event, targetCardId: event.sourceCardId })).toBe(true);
+        expect(isSelfEffectTarget(event)).toBe(false);
+    });
+
+    it("identifies effects targeting cards on the source player's side", () => {
+        expect(isSameSideEffectTarget({ ...event, targetOwner: event.sourceOwner })).toBe(true);
+        expect(isSameSideEffectTarget(event)).toBe(false);
+    });
+
+    it("selects horizontal arrow directions for same-side fields even with empty slots between them", () => {
+        expect(getSameSideDirection("myDigi1", "myDigi4")).toBe("right");
+        expect(getSameSideDirection("opponentDigi7", "opponentDigi3")).toBe("left");
+        expect(getSameSideDirection("myDigi1", "opponentDigi2")).toBeNull();
+        expect(getSameSideDirection("myDigi1", "myDigi1")).toBeNull();
     });
 
     it("formats the structured event consistently", () => {

--- a/frontend/src/utils/effectTargeting.ts
+++ b/frontend/src/utils/effectTargeting.ts
@@ -1,0 +1,30 @@
+export type EffectTargetPayload = {
+    sourceCardId: string;
+    targetCardId: string;
+    sourceLocation: string;
+    targetLocation: string;
+    timing: string;
+    effectText: string;
+};
+
+export type EffectTargetEvent = EffectTargetPayload & {
+    sender: string;
+    sourceOwner: string;
+    targetOwner: string;
+    sourceName: string;
+    targetName: string;
+};
+
+export function flipEffectLocation(location: string): string {
+    if (location.startsWith("my")) return location.replace(/^my/, "opponent");
+    if (location.startsWith("opponent")) return location.replace(/^opponent/, "my");
+    return location;
+}
+
+export function orientEffectLocation(location: string, sender: string, currentUser: string): string {
+    return sender === currentUser ? location : flipEffectLocation(location);
+}
+
+export function formatEffectTargetMessage(event: EffectTargetEvent): string {
+    return `${event.sourceOwner}'s ${event.sourceName} is targeting ${event.targetOwner}'s ${event.targetName} with [${event.timing}]: ${event.effectText}`;
+}

--- a/frontend/src/utils/effectTargeting.ts
+++ b/frontend/src/utils/effectTargeting.ts
@@ -1,5 +1,6 @@
 export type EffectTargetPayload = {
     sourceCardId: string;
+    effectSourceCardId?: string | null;
     targetCardId: string;
     sourceLocation: string;
     targetLocation: string;
@@ -12,6 +13,7 @@ export type EffectTargetEvent = EffectTargetPayload & {
     sourceOwner: string;
     targetOwner: string;
     sourceName: string;
+    effectSourceName?: string | null;
     targetName: string;
 };
 
@@ -49,8 +51,11 @@ export function getSameSideDirection(
 }
 
 export function formatEffectTargetMessage(event: EffectTargetEvent): string {
-    if (isSelfEffectTarget(event)) {
-        return `${event.sourceOwner}'s ${event.sourceName} is targeting itself with [${event.timing}]: ${event.effectText}`;
-    }
-    return `${event.sourceOwner}'s ${event.sourceName} is targeting ${event.targetOwner}'s ${event.targetName} with [${event.timing}]: ${event.effectText}`;
+    const target = isSelfEffectTarget(event)
+        ? "itself"
+        : `${event.targetOwner}'s ${event.targetName}`;
+    const action = event.effectSourceName
+        ? `is using ${event.effectSourceName} to target`
+        : "is targeting";
+    return `${event.sourceOwner}'s ${event.sourceName} ${action} ${target} with [${event.timing}]: ${event.effectText}`;
 }

--- a/frontend/src/utils/effectTargeting.ts
+++ b/frontend/src/utils/effectTargeting.ts
@@ -49,5 +49,8 @@ export function getSameSideDirection(
 }
 
 export function formatEffectTargetMessage(event: EffectTargetEvent): string {
+    if (isSelfEffectTarget(event)) {
+        return `${event.sourceOwner}'s ${event.sourceName} is targeting itself with [${event.timing}]: ${event.effectText}`;
+    }
     return `${event.sourceOwner}'s ${event.sourceName} is targeting ${event.targetOwner}'s ${event.targetName} with [${event.timing}]: ${event.effectText}`;
 }

--- a/frontend/src/utils/effectTargeting.ts
+++ b/frontend/src/utils/effectTargeting.ts
@@ -25,6 +25,29 @@ export function orientEffectLocation(location: string, sender: string, currentUs
     return sender === currentUser ? location : flipEffectLocation(location);
 }
 
+export function isSelfEffectTarget(event: EffectTargetPayload): boolean {
+    return event.sourceCardId === event.targetCardId;
+}
+
+export function isSameSideEffectTarget(event: EffectTargetEvent): boolean {
+    return event.sourceOwner === event.targetOwner;
+}
+
+export function getSameSideDirection(
+    sourceLocation: string,
+    targetLocation: string
+): "left" | "right" | null {
+    const sourceMatch = sourceLocation.match(/^(my|opponent)Digi(\d+)$/);
+    const targetMatch = targetLocation.match(/^(my|opponent)Digi(\d+)$/);
+    if (!sourceMatch || !targetMatch || sourceMatch[1] !== targetMatch[1]) return null;
+
+    const sourceField = Number(sourceMatch[2]);
+    const targetField = Number(targetMatch[2]);
+    if (sourceField === targetField) return null;
+
+    return targetField > sourceField ? "right" : "left";
+}
+
 export function formatEffectTargetMessage(event: EffectTargetEvent): string {
     return `${event.sourceOwner}'s ${event.sourceName} is targeting ${event.targetOwner}'s ${event.targetName} with [${event.timing}]: ${event.effectText}`;
 }

--- a/frontend/src/utils/effectTiming.test.ts
+++ b/frontend/src/utils/effectTiming.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { cleanEffectText, parseEffectTimingGroups } from "./effectTiming.ts";
+
+describe("parseEffectTimingGroups", () => {
+    it("groups consecutive activation timings under the same effect", () => {
+        const groups = parseEffectTimingGroups(
+            "[On Play] [When Digivolving] If you have 1 or fewer Tamers, play 1 Tamer.\n" +
+                "[All Turns] This Digimon may digivolve."
+        );
+
+        expect(groups).toHaveLength(2);
+        expect(groups[0]).toMatchObject({
+            timings: ["On Play", "When Digivolving"],
+            qualifiers: [],
+            effectText: "If you have 1 or fewer Tamers, play 1 Tamer.",
+        });
+        expect(groups[1]).toMatchObject({
+            timings: ["All Turns"],
+            effectText: "This Digimon may digivolve.",
+        });
+    });
+
+    it("keeps frequency labels as qualifiers instead of separate effects", () => {
+        const [group] = parseEffectTimingGroups(
+            "[When Attacking] [Once Per Turn] By placing 1 card, ＜Draw 1＞."
+        );
+
+        expect(group.timings).toEqual(["When Attacking"]);
+        expect(group.qualifiers).toEqual(["Once Per Turn"]);
+        expect(group.effectText).toBe("By placing 1 card, Draw 1.");
+    });
+
+    it("does not create a group from a standalone frequency label", () => {
+        expect(parseEffectTimingGroups("[Once Per Turn] Do something.")).toEqual([]);
+    });
+
+    it("returns an empty list for effects without a timing", () => {
+        expect(parseEffectTimingGroups("Delete 1 of your opponent's Digimon.")).toEqual([]);
+    });
+});
+
+describe("cleanEffectText", () => {
+    it("removes card-data delimiters and normalizes whitespace", () => {
+        expect(cleanEffectText("  [Rule]  Use ＜Blocker＞.\nThen draw. ")).toBe("Rule Use Blocker. Then draw.");
+    });
+});

--- a/frontend/src/utils/effectTiming.ts
+++ b/frontend/src/utils/effectTiming.ts
@@ -1,0 +1,99 @@
+export const EFFECT_TIMINGS = [
+    "On Play",
+    "When Digivolving",
+    "When Attacking",
+    "When Linking",
+    "End of Attack",
+    "On Deletion",
+    "Your Turn",
+    "All Turns",
+    "Opponent's Turn",
+    "End of Opponent's Turn",
+    "Start of Your Turn",
+    "End of Your Turn",
+    "Enf of Opponent's Turn",
+    "Security",
+    "Main",
+    "Start of Your Main Phase",
+    "Start of Opponent's Main Phase",
+    "Once Per Turn",
+    "Twice Per Turn",
+    "Trash",
+    "Hand",
+    "Breeding",
+    "Counter",
+    "End of All Turns",
+] as const;
+
+const NON_ACTIONABLE_TIMINGS = new Set(["Once Per Turn", "Twice Per Turn", "Trash", "Hand", "Breeding"]);
+const EFFECT_TIMING_SET = new Set<string>(EFFECT_TIMINGS);
+
+export type EffectTimingToken = {
+    label: string;
+    start: number;
+    end: number;
+    actionable: boolean;
+};
+
+export type EffectTimingGroup = {
+    timings: string[];
+    qualifiers: string[];
+    effectText: string;
+    rawEffectText: string;
+    timingTokens: EffectTimingToken[];
+};
+
+export function isActionableEffectTiming(label: string): boolean {
+    return EFFECT_TIMING_SET.has(label) && !NON_ACTIONABLE_TIMINGS.has(label);
+}
+
+export function cleanEffectText(text: string): string {
+    return text
+        .replace(/\[([^\]]+)]/g, "$1")
+        .replace(/＜([^＞]+)＞/g, "$1")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+export function parseEffectTimingGroups(text: string): EffectTimingGroup[] {
+    const timingTokens: EffectTimingToken[] = [];
+    const bracketPattern = /\[([^\]]+)]/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = bracketPattern.exec(text)) !== null) {
+        const label = match[1];
+        if (!EFFECT_TIMING_SET.has(label)) continue;
+        timingTokens.push({
+            label,
+            start: match.index,
+            end: bracketPattern.lastIndex,
+            actionable: isActionableEffectTiming(label),
+        });
+    }
+
+    const runs: EffectTimingToken[][] = [];
+    for (const token of timingTokens) {
+        const currentRun = runs.at(-1);
+        const previousToken = currentRun?.at(-1);
+        if (currentRun && previousToken && text.slice(previousToken.end, token.start).trim() === "") {
+            currentRun.push(token);
+        } else {
+            runs.push([token]);
+        }
+    }
+
+    const actionableRuns = runs.filter((run) => run.some((token) => token.actionable));
+
+    return actionableRuns.map((run, index) => {
+        const nextRun = actionableRuns[index + 1];
+        const rawEffectText = text.slice(run.at(-1)!.end, nextRun?.[0].start ?? text.length).trim();
+
+        return {
+            timings: run.filter((token) => token.actionable).map((token) => token.label),
+            qualifiers: run.filter((token) => !token.actionable).map((token) => token.label),
+            effectText: cleanEffectText(rawEffectText),
+            rawEffectText,
+            timingTokens: run,
+        };
+    });
+}


### PR DESCRIPTION
## Summary

  - Add interactive effect timing labels to card details.
  - Parse card text into timing and effect groups.
  - Add single-target selection mode with a red targeting cursor.
  - Support cancellation through Escape, right-click, and empty-space clicks.
  - Highlight valid field targets and the active source card.
  - Send structured /effectTarget WebSocket events containing:
      - Source and target card IDs
      - Board locations
      - Selected timing
      - Effect text
      - Evolution-source card ID when using an inherited effect

  - Synchronize target animations, effect animations, arrows, and game-log messages between players.
  - Validate source, target, and evolution-source card IDs against backend board state before broadcasting.
  - Format self-targeting messages using “itself.”
  - Identify inherited effects with wording such as “is using Koromon to target…”
  - Display friendly/same-side effect messages in green and opponent-targeting messages in red.
  - Suppress arrows for self-targeted effects.
  - Render same-side arrows horizontally through centered field anchors.
  - Separate inherited effects into individual source-card sections with grey name and level identifiers.
  - Preserve evolution-stack order and associate timing buttons with the exact source card.

  ## Testing

  - Added unit tests for effect parsing, targeting state, location orientation, message formatting, self-targeting, same-side targeting, and inherited-
    source formatting.

  - Added opponent-card WebSocket propagation regression tests.
  - Added backend multiplayer tests covering:
      - Valid event broadcasting and history
      - Invalid source and target IDs
      - Incorrect board locations
      - Malformed payloads
      - Validated evolution-source cards

  - Verified the frontend production build and TypeScript compilation.

<img width="343" height="234" alt="Screenshot 2026-07-28 at 7 10 32 PM" src="https://github.com/user-attachments/assets/62b94b12-25ef-40e4-a0b6-c0079ed22431" />
<img width="285" height="523" alt="Screenshot 2026-07-28 at 7 20 08 PM" src="https://github.com/user-attachments/assets/64bb6e2f-d4cd-4338-b5e1-d5b31c7940da" />
<img width="344" height="456" alt="Screenshot 2026-07-28 at 7 20 17 PM" src="https://github.com/user-attachments/assets/117484c5-bc8f-4ac3-ba14-aaab29fa460f" />
<img width="850" height="233" alt="Screenshot 2026-07-28 at 7 20 40 PM" src="https://github.com/user-attachments/assets/113e5a03-2f0b-4986-bed0-bea34714f263" />
![Screenshot 2026-07-28 at 7 42 52 PM](https://github.com/user-attachments/assets/d6058851-f659-432d-93f8-34ae750337dd)
