### PR TITLE
Auto-detect card keywords

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { useGeneralStates } from "../hooks/useGeneralStates.ts";
 import { tamerLocations, useGameBoardStates } from "../hooks/useGameBoardStates.ts";
 import { getNumericModifier, numbersWithModifiers } from "../utils/functions.ts";
-import { CSSProperties, useEffect, useState } from "react";
+import { CSSProperties, useEffect, useMemo, useState } from "react";
 import Lottie from "lottie-react";
 import activateEffectAnimation from "../assets/lotties/activate-effect-animation.json";
 import targetAnimation from "../assets/lotties/target-animation.json";
@@ -18,6 +18,7 @@ import { OpenedCardDialog, useGameUIStates } from "../hooks/useGameUIStates.ts";
 import { useLongPress } from "../hooks/useLongPress.ts";
 import { useSettingStates } from "../hooks/useSettingStates.ts";
 import { useImageCache } from "../hooks/useImageCache.ts";
+import { extractStandaloneEffectKeywords } from "../utils/effectKeywords.ts";
 
 const myDigimonLocations = [
     "myDigi1",
@@ -379,6 +380,10 @@ export default function Card(props: CardProps) {
         [...myBALocations, ...opponentBALocations].includes(location) &&
         (card.cardType.includes("Digimon") || isTamerWithDP);
     const modifiers = isModifiersAllowed ? card.modifiers : undefined;
+    const displayedKeywords = useMemo(
+        () => [...new Set([...extractStandaloneEffectKeywords(card.mainEffect), ...(modifiers?.keywords ?? [])])],
+        [card.mainEffect, modifiers?.keywords]
+    );
 
     const linkDP = linkCardsForLocation.reduce((sum, card) => sum + (card.linkDP ?? 0), 0);
 
@@ -507,7 +512,7 @@ export default function Card(props: CardProps) {
                                         </ColorStack>
                                     )}
                                     <KeywordWrapper>
-                                        {modifiers?.keywords
+                                        {displayedKeywords
                                             .filter((w) => w !== "SICK" && w !== "TAUNT")
                                             .map((keyword) => (
                                                 <ModifierSpan keyword={keyword} key={`${keyword}_${card.id}`}>

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -380,9 +380,24 @@ export default function Card(props: CardProps) {
         [...myBALocations, ...opponentBALocations].includes(location) &&
         (card.cardType.includes("Digimon") || isTamerWithDP);
     const modifiers = isModifiersAllowed ? card.modifiers : undefined;
+    const inheritedKeywords = useMemo(() => {
+        const isTopStackCard = index === locationCards.length - 1;
+        if (!isTopStackCard || !locationsWithInheritedInfo.includes(location)) return [];
+
+        return locationCards
+            .slice(0, -1)
+            .filter((sourceCard) => sourceCard.isFaceUp)
+            .flatMap((sourceCard) => extractStandaloneEffectKeywords(sourceCard.inheritedEffect));
+    }, [index, location, locationCards]);
     const displayedKeywords = useMemo(
-        () => [...new Set([...extractStandaloneEffectKeywords(card.mainEffect), ...(modifiers?.keywords ?? [])])],
-        [card.mainEffect, modifiers?.keywords]
+        () => [
+            ...new Set([
+                ...extractStandaloneEffectKeywords(card.mainEffect),
+                ...inheritedKeywords,
+                ...(modifiers?.keywords ?? []),
+            ]),
+        ],
+        [card.mainEffect, inheritedKeywords, modifiers?.keywords]
     );
 
     const linkDP = linkCardsForLocation.reduce((sum, card) => sum + (card.linkDP ?? 0), 0);

--- a/frontend/src/utils/effectKeywords.ts
+++ b/frontend/src/utils/effectKeywords.ts
@@ -1,6 +1,11 @@
 const standaloneKeywordLine = /^\s*(?:＜[^＞\r\n]+＞[\s.,;:]*)+$/;
 const keywordTag = /＜([^＞\r\n]+)＞/g;
 
+function getFieldKeywordLabel(keyword: string): string {
+    if (/^Decode(?:\s|\(|$)/i.test(keyword)) return "Decode";
+    return keyword;
+}
+
 /**
  * Extracts persistent keyword labels that are presented as standalone effects.
  *
@@ -13,9 +18,10 @@ export function extractStandaloneEffectKeywords(effect?: string | null): string[
 
     const keywords = effect.split(/\r?\n/).flatMap((line) => {
         if (!standaloneKeywordLine.test(line)) return [];
-        return Array.from(line.matchAll(keywordTag), (match) => match[1].trim()).filter(Boolean);
+        return Array.from(line.matchAll(keywordTag), (match) => match[1].trim())
+            .filter(Boolean)
+            .map(getFieldKeywordLabel);
     });
 
     return [...new Set(keywords)];
 }
-

--- a/frontend/src/utils/effectKeywords.ts
+++ b/frontend/src/utils/effectKeywords.ts
@@ -1,0 +1,21 @@
+const standaloneKeywordLine = /^\s*(?:＜[^＞\r\n]+＞[\s.,;:]*)+$/;
+const keywordTag = /＜([^＞\r\n]+)＞/g;
+
+/**
+ * Extracts persistent keyword labels that are presented as standalone effects.
+ *
+ * Keywords mentioned inside timed effect text are intentionally ignored. For
+ * example, `[All Turns] This Digimon gains ＜Blocker＞.` is effect prose rather
+ * than a standalone keyword line and must not add a field badge.
+ */
+export function extractStandaloneEffectKeywords(effect?: string | null): string[] {
+    if (!effect) return [];
+
+    const keywords = effect.split(/\r?\n/).flatMap((line) => {
+        if (!standaloneKeywordLine.test(line)) return [];
+        return Array.from(line.matchAll(keywordTag), (match) => match[1].trim()).filter(Boolean);
+    });
+
+    return [...new Set(keywords)];
+}
+


### PR DESCRIPTION
## Summary
Created functionality to support auto detection of Card Keywords. 

## Testing
- Frontend production build

<img width="582" height="206" alt="Screenshot 2026-08-04 at 10 53 14 AM" src="https://github.com/user-attachments/assets/12141284-e3ea-4379-aee3-cfe7d1032205" />
<img width="388" height="199" alt="Screenshot 2026-08-04 at 11 43 06 AM" src="https://github.com/user-attachments/assets/a48afbbe-3388-415b-96ed-d49b7c4d2528" />
<img width="890" height="345" alt="Screenshot 2026-08-04 at 11 44 00 AM" src="https://github.com/user-attachments/assets/7471f2eb-27c6-4ea2-94dc-874a0af87dcb" />

Edge Cases verified:
- Inherited card effects will have their keywords placed on the top card. 
- Decode (xxxx....) will just display as "Decode" 
- cards that have ... gains X effect will not display and player has to manually put in the effect.
